### PR TITLE
Fix exception thrown on confirmation page

### DIFF
--- a/paypal.php
+++ b/paypal.php
@@ -1551,7 +1551,7 @@ class PayPal extends \PaymentModule implements WidgetInterface
 
         ProcessLoggerHandler::openLogger();
         ProcessLoggerHandler::logInfo(
-            $orderState->name,
+            is_array($orderState->name) ? $orderState->name[$order->id_lang] : $orderState->name,
             isset($transaction['transaction_id']) ? $transaction['transaction_id'] : null,
             $this->currentOrder,
             (int) $id_cart,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Paypal PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Fixes exception on the confirmation page `Warning: strip_tags() expects parameter 1 to be string`, due to translated `OrderState->name`
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #138.
| How to test?  | The exception should no longer be thrown

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
