### PR TITLE
Do not throw an error if there is no payment found

### DIFF
--- a/services/ActualizeTotalPaid.php
+++ b/services/ActualizeTotalPaid.php
@@ -41,8 +41,8 @@ class ActualizeTotalPaid
         $order->save();
         $payments = $order->getOrderPayments();
 
-        if (count($payments) > 1) {
-            // todo: implement
+        if (count($payments) != 1) {
+            // todo: implement if none or more than one are found
             return;
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Paypal PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | If the payment is not found, the webhook script throws an error. This PR avoids the error, but it does not address the root issue (why the payment isn't found).
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #141.
| How to test?  | This PR fixes the PHP errors thrown on the webhook. I don't know how works paypal API though. Maybe there must be another part to this correction that addresses the issue on the side of paypal.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
