### PR TITLE
refs #38495 redirection mode

### DIFF
--- a/controllers/front/ecInit.php
+++ b/controllers/front/ecInit.php
@@ -40,7 +40,7 @@ class PaypalEcInitModuleFrontController extends PaypalAbstarctModuleFrontControl
         $this->values['getToken'] = Tools::getvalue('getToken');
         $this->values['credit_card'] = Tools::getvalue('credit_card');
         $this->values['short_cut'] = 0;
-        $this->setMethod(AbstractMethodPaypal::load('EC'));
+        $this->setMethod(AbstractMethodPaypal::load($this->getMethodType(Tools::getAllValues())));
     }
 
     /**
@@ -50,14 +50,7 @@ class PaypalEcInitModuleFrontController extends PaypalAbstarctModuleFrontControl
     {
         try {
             $this->method->setParameters($this->values);
-            $url = $this->method->init()->getApproveLink();
-
-            if ($this->values['getToken']) {
-                $this->jsonValues = ['success' => true, 'token' => $this->method->getPaymentId()];
-            } else {
-                //$this->redirectUrl = $url.'&useraction=commit';
-                $this->redirectUrl = $url;
-            }
+            $this->redirectUrl = $this->method->init()->getApproveLink();
         } catch (PaypalAddons\classes\PaypalException $e) {
             $this->_errors['error_code'] = $e->getCode();
             $this->_errors['error_msg'] = $e->getMessage();
@@ -79,5 +72,14 @@ class PaypalEcInitModuleFrontController extends PaypalAbstarctModuleFrontControl
     public function setMethod($method)
     {
         $this->method = $method;
+    }
+
+    protected function getMethodType($requestData)
+    {
+        if (empty($requestData['methodType'])) {
+            return 'EC';
+        } else {
+            return $requestData['methodType'];
+        }
     }
 }

--- a/paypal.php
+++ b/paypal.php
@@ -1003,6 +1003,8 @@ class PayPal extends \PaymentModule implements WidgetInterface
     {
         $paymentOption = new PaymentOption();
         $paymentOption->setCallToActionText($this->l('PayPal'));
+        $additionalInformation = '';
+
         $paymentOption->setAction(
             sprintf(
                 'javascript:alert(\'%s\');',
@@ -1016,7 +1018,22 @@ class PayPal extends \PaymentModule implements WidgetInterface
                 break;
             }
         }
-        $additionalInformation = $this->getShortcutPaymentStep()->render();
+
+        if (Configuration::get('PAYPAL_EXPRESS_CHECKOUT_IN_CONTEXT')) {
+            $additionalInformation .= $this->getShortcutPaymentStep()->render();
+        } else {
+            $paymentOption->setAction(
+                $this->context->link->getModuleLink(
+                    $this->name,
+                    'ecInit',
+                    [
+                        'credit_card' => '0',
+                        'methodType' => 'PPP',
+                    ],
+                    true
+                )
+            );
+        }
 
         if (!$is_virtual && Configuration::get('PAYPAL_API_ADVANTAGES')) {
             $additionalInformation .= $this->context->smarty->fetch('module:paypal/views/templates/front/payment_infos.tpl');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Paypal PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | For a german merchant, <br/> In the "redirect" mode, the Prestashop standard button is not correctly displayed.
| Type?         | bug fix
| BC breaks?    |  no
| Deprecations? |  no
| Fixed ticket? | #156
| How to test?  | Shop with a german default country, in 'redirect' mode standard payment button should always be displayed.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
