### PR TITLE
compatibility with PS 8.0.1 and 1.7.8.8 (38685)

### DIFF
--- a/vendor/ppbtlib/src/Db/DbTable.php
+++ b/vendor/ppbtlib/src/Db/DbTable.php
@@ -104,7 +104,13 @@ class DbTable
         $alter = $this->alterFields();
 
         if (!empty($alter)) {
-            return $this->db->execute($alter);
+            $result = true;
+
+            foreach ($alter as $request) {
+                $result &= $this->db->execute($request);
+            }
+
+            return $result;
         }
         $this->alterKeys();
 
@@ -147,7 +153,7 @@ class DbTable
             }
         }
 
-        return implode("\r\n", $alters);
+        return $alters;
     }
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Since PS 1.8.8.8 and 8.0.1, PrestaShop add a BC on several SQL request made in a same execution. The upgrade script that add fields used multiquery.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes 38685
