### PR TITLE
refs #38364 redirect mode for alternative method

### DIFF
--- a/classes/API/Request/PaypalConfirmPaymentSourceRequest.php
+++ b/classes/API/Request/PaypalConfirmPaymentSourceRequest.php
@@ -30,7 +30,7 @@ use Exception;
 use PaypalAddons\classes\AbstractMethodPaypal;
 use PaypalAddons\classes\API\ExtensionSDK\ConfirmPaymentSource;
 use PaypalAddons\classes\API\Response\Error;
-use PaypalAddons\classes\API\Response\Response;
+use PaypalAddons\classes\API\Response\ResponseConfirmationPaymentSource;
 use PaypalAddons\services\Builder\ConfirmPaymentSourceBuilder;
 use PayPalCheckoutSdk\Core\PayPalHttpClient;
 use PayPalHttp\HttpException;
@@ -62,7 +62,11 @@ class PaypalConfirmPaymentSourceRequest extends RequestAbstract
 
             if ($exec->statusCode >= 200 && $exec->statusCode < 300) {
                 $response->setSuccess(true)
-                    ->setData($exec);
+                    ->setData($exec)
+                    ->setPaymentId($exec->result->id)
+                    ->setStatusCode($exec->statusCode)
+                    ->setApproveLink($this->getLink('approve', $exec->result->links))
+                    ->setPayerActionLink($this->getLink('payer-action', $exec->result->links));
             } else {
                 $response->setSuccess(false)->setData($exec);
             }
@@ -99,11 +103,28 @@ class PaypalConfirmPaymentSourceRequest extends RequestAbstract
 
     protected function initResponse()
     {
-        return new Response();
+        return new ResponseConfirmationPaymentSource();
     }
 
     protected function initBodyBuilder()
     {
         return new ConfirmPaymentSourceBuilder($this->apmMethod);
+    }
+
+    /**
+     * @param $nameLink string
+     * @param $links array
+     *
+     * @return string
+     */
+    protected function getLink($nameLink, $links)
+    {
+        foreach ($links as $link) {
+            if ($link->rel == $nameLink) {
+                return $link->href;
+            }
+        }
+
+        return '';
     }
 }

--- a/classes/API/Response/ResponseConfirmationPaymentSource.php
+++ b/classes/API/Response/ResponseConfirmationPaymentSource.php
@@ -1,0 +1,54 @@
+<?php
+/*
+ * 2007-2023 PayPal
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ *  versions in the future. If you wish to customize PrestaShop for your
+ *  needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author 2007-2023 PayPal
+ *  @author 202 ecommerce <tech@202-ecommerce.com>
+ *  @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ *  @copyright PayPal
+ *
+ */
+
+namespace PaypalAddons\classes\API\Response;
+
+class ResponseConfirmationPaymentSource extends ResponseOrderCreate
+{
+    /** @var string */
+    protected $payerActionLink;
+
+    /**
+     * @return string
+     */
+    public function getPayerActionLink()
+    {
+        return (string) $this->payerActionLink;
+    }
+
+    /**
+     * @param string $link
+     *
+     * @return self
+     */
+    public function setPayerActionLink($link)
+    {
+        $this->payerActionLink = (string) $link;
+
+        return $this;
+    }
+}

--- a/classes/AbstractMethodPaypal.php
+++ b/classes/AbstractMethodPaypal.php
@@ -133,7 +133,7 @@ abstract class AbstractMethodPaypal extends AbstractMethod
     }
 
     /**
-     * @return \PaypalAddons\classes\API\Response\ResponseOrderCreate
+     * @return \PaypalAddons\classes\API\Response\ResponseConfirmationPaymentSource
      *
      * @throws Exception
      */
@@ -146,7 +146,7 @@ abstract class AbstractMethodPaypal extends AbstractMethod
             throw new \Exception($response->getError()->getMessage());
         }
 
-        return $response;
+        return $confirmation;
     }
 
     /**

--- a/controllers/front/ecInit.php
+++ b/controllers/front/ecInit.php
@@ -41,6 +41,7 @@ class PaypalEcInitModuleFrontController extends PaypalAbstarctModuleFrontControl
         $this->values['credit_card'] = Tools::getvalue('credit_card');
         $this->values['short_cut'] = 0;
         $this->setMethod(AbstractMethodPaypal::load($this->getMethodType(Tools::getAllValues())));
+        $this->values['apmMethod'] = Tools::getValue('apmMethod', null);
     }
 
     /**
@@ -50,7 +51,12 @@ class PaypalEcInitModuleFrontController extends PaypalAbstarctModuleFrontControl
     {
         try {
             $this->method->setParameters($this->values);
-            $this->redirectUrl = $this->method->init()->getApproveLink();
+
+            if (empty($this->values['apmMethod'])) {
+                $this->redirectUrl = $this->method->init()->getApproveLink();
+            } else {
+                $this->redirectUrl = $this->method->initApm($this->values['apmMethod'])->getPayerActionLink();
+            }
         } catch (PaypalAddons\classes\PaypalException $e) {
             $this->_errors['error_code'] = $e->getCode();
             $this->_errors['error_msg'] = $e->getMessage();

--- a/paypal.php
+++ b/paypal.php
@@ -952,14 +952,24 @@ class PayPal extends \PaymentModule implements WidgetInterface
         foreach ($optionsMap as $optionMap) {
             $paymentOption = new PaymentOption();
             $paymentOption->setCallToActionText($optionMap['label']);
-            $paymentOption->setAction(
-                sprintf(
-                    'javascript:alert(\'%s\');',
-                    $this->l('Should use the alternative payment button') // todo: specify message
-                )
-            );
             $paymentOption->setModuleName('paypal_' . $optionMap['method']);
-            $paymentOption->setAdditionalInformation($this->initApmCollection([$optionMap['method']])->render());
+
+            if (Configuration::get('PAYPAL_EXPRESS_CHECKOUT_IN_CONTEXT')) {
+                $paymentOption->setAdditionalInformation($this->initApmCollection([$optionMap['method']])->render());
+            } else {
+                $paymentOption->setAction(
+                    $this->context->link->getModuleLink(
+                        $this->name,
+                        'ecInit',
+                        [
+                            'credit_card' => '0',
+                            'methodType' => 'PPP',
+                            'apmMethod' => $optionMap['method'],
+                        ],
+                        true
+                    )
+                );
+            }
 
             $paymentOptions[] = $paymentOption;
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Paypal PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Fix redirect mode for german merchants.<br />Add redirect mode for ACDC payment methods (sofort, giropay etc...)
| Type?         | bug fix and improvement
| BC breaks?    | No
| Deprecations? | No
| Fixed ticket? | None
| How to test?  | German merchants will have the redirect mode fixed (the same behaviour as in context before fix).<br />Now ACDC payment methods will work with redirect mode (no more popup displayed).

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
