### PR TITLE
Payment buttons - on checkout loading

### DIFF
--- a/_dev/js/tools.js
+++ b/_dev/js/tools.js
@@ -78,7 +78,15 @@ export const Tools = {
       } else {
         Tools.disable(disabledElement);
       }
-    })
+    });
+
+    $('.payment-option').click(function() {
+      if (checkBox.checked) {
+        Tools.enable(disabledElement);
+      } else {
+        Tools.disable(disabledElement);
+      }
+    });
   },
 
   disable(element) {

--- a/views/templates/_partials/javascript.tpl
+++ b/views/templates/_partials/javascript.tpl
@@ -25,11 +25,14 @@
  *}
 
 <script>
-  {if isset($JSvars)}
-    {foreach from=$JSvars key=varName item=varValue}
-    var {$varName} = {$varValue|json_encode nofilter};
-    {/foreach}
-  {/if}
+ {if isset($JSvars)}    
+   {foreach from=$JSvars key=varName item=varValue}
+       {assign var="isNotJSVarsvalue" value=($varName == '0' && $varValue == '1')}
+       {if $isNotJSVarsvalue === false}        
+           var {$varName} = {$varValue|json_encode nofilter};
+       {/if}
+   {/foreach}
+ {/if}
 </script>
 
 {if isset($JSscripts) && is_array($JSscripts) && false === empty($JSscripts)}

--- a/views/templates/bnpl/bnpl-payment-step.tpl
+++ b/views/templates/bnpl/bnpl-payment-step.tpl
@@ -65,9 +65,23 @@
                 document.querySelector('[paypal-wrong-button-message]').style.display = 'block';
             }
         });
+        paypalInitBNPLButtons(true);     
     });
 
     if (typeof BNPL != "undefined") {
+        paypalInitBNPLButtons(false);
+    } else {
+        document.addEventListener('paypal-after-init-bnpl-button', function (event) {
+          paypalInitBNPLButtons(false);
+        })
+    }
+
+    function paypalInitBNPLButtons(repeatTimer) {
+        if (typeof BNPL == 'undefined' && repeatTimer === true) {
+          setTimeout(paypalInitBNPLButtons, 150);
+        } else {
+          return;
+        }
         BNPL.addMarkTo(
           document.querySelector('[data-module-name="paypal_bnpl"]').closest('.payment-option'),
           {
@@ -83,24 +97,6 @@
           '[data-module-name="paypal_bnpl"]',
           '[paypal-bnpl-button-container]'
         );
-    } else {
-        document.addEventListener('paypal-after-init-bnpl-button', function (event) {
-            BNPL.addMarkTo(
-              document.querySelector('[data-module-name="paypal_bnpl"]').closest('.payment-option'),
-              {
-                display: "table-cell"
-              }
-            );
-            BNPL.disableTillConsenting();
-            BNPL.hideElementTillPaymentOptionChecked(
-                '[data-module-name="paypal_bnpl"]',
-                '#payment-confirmation'
-            );
-            BNPL.showElementIfPaymentOptionChecked(
-              '[data-module-name="paypal_bnpl"]',
-              '[paypal-bnpl-button-container]'
-            );
-        })
     }
   </script>
 {/block}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Paypal PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Fix payment selected with button(s) disabled.<br />Make the same process of terms of agreement checkbox on payment change.
| Type?         | improvement / bug fix
| BC breaks?    | No
| Deprecations? | No
| Fixed ticket? | None
| How to test?  | With a slow network, approving the terms of service on a website and when you select a payment method the paypal buttons to pay should be correctly enabled.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
