### PR TITLE
Track only paypal orders (39758)

### DIFF
--- a/paypal.php
+++ b/paypal.php
@@ -3181,6 +3181,11 @@ class PayPal extends \PaymentModule implements WidgetInterface
 
         /** @var $paypalOrder PaypalOrder */
         $paypalOrder = PaypalOrder::loadByOrderId($params['order']->id);
+
+        if (false === Validate::isLoadedObject($paypalOrder)) {
+            return;
+        }
+
         $method = AbstractMethodPaypal::load($this->paypal_method);
         $response = $method->addOrderTrackingInfo($paypalOrder);
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Added verification to avoid attempts to track not Paypal order
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes 39758
| How to test?  | Create an order and pay it by check (or another payment tool except Paypal). Add track info in BO. In the logs of the module, you will find the message "Adding tracking info is failed"
