### PR TITLE
Hotfixes/41114 bnpl form error500 if not eligible

### DIFF
--- a/202/build.xml
+++ b/202/build.xml
@@ -30,7 +30,7 @@
     <property name="src-dir" value="${basedir}" />
     <property name="TARGETNAME" value="paypal" />
     <property name="TARGETBRANCH" value="${env.GIT_BRANCH}" />
-    <property name="TARGETVERSION" value="6.0.0" />
+    <property name="TARGETVERSION" value="6.0.1" />
     <property name="PHPVERSION" value="5.6" />
     <property name="PSVERSION" value="1.7.5.2" />
 

--- a/_dev/js/admin/steps.js
+++ b/_dev/js/admin/steps.js
@@ -23,7 +23,7 @@ class Steps {
       this.updateStepsProgress();
 
       if (this.getCurrentStepIndex() == -1) {
-        $(e.detail.form).closest('.modal').modal('hide');
+        $(e.originalEvent.detail.form).closest('.modal').modal('hide');
         document.location.reload();
       }
     });

--- a/_dev/js/admin/steps.js
+++ b/_dev/js/admin/steps.js
@@ -14,7 +14,7 @@ class Steps {
 
   registerEvents() {
     $(document).on('afterFormSaved', (e) => {
-      if (e.detail.form.classList.contains('form-modal') == false) {
+      if (e.originalEvent.detail.form.classList.contains('form-modal') == false) {
         return;
       }
 

--- a/_dev/js/admin/steps.js
+++ b/_dev/js/admin/steps.js
@@ -4,6 +4,7 @@ class Steps {
     this.btn = '[data-btn-action]';
     this.content = '[data-step-content]';
     this.currentStepBadge = '[data-badge-current-step]';
+    this.maxStepBadge = '[data-badge-max-step]';
     this.stepsProgress = '[data-steps-progress]';
     this.controller = document.location.href;
   }
@@ -62,6 +63,7 @@ class Steps {
     const currentStepIndex = this.getCurrentStepIndex();
     if (currentStepIndex <= this.getLastStepIndex()) {
       this.$stepsContainer.find(this.currentStepBadge).html(currentStepIndex + 1);
+      this.$stepsContainer.find(this.maxStepBadge).html($(this.content).length);
     }
   }
 

--- a/_dev/js/admin/steps.js
+++ b/_dev/js/admin/steps.js
@@ -11,6 +11,7 @@ class Steps {
 
   init() {
     this.registerEvents();
+    this.$stepsContainer.find(this.maxStepBadge).html($(this.content).length);
   }
 
   registerEvents() {
@@ -63,7 +64,6 @@ class Steps {
     const currentStepIndex = this.getCurrentStepIndex();
     if (currentStepIndex <= this.getLastStepIndex()) {
       this.$stepsContainer.find(this.currentStepBadge).html(currentStepIndex + 1);
-      this.$stepsContainer.find(this.maxStepBadge).html($(this.content).length);
     }
   }
 

--- a/controllers/admin/AdminPaypalConfigurationController.php
+++ b/controllers/admin/AdminPaypalConfigurationController.php
@@ -101,6 +101,7 @@ class AdminPaypalConfigurationController extends \ModuleAdminController
 
         $tpl->assign([
             'moduleDir' => _MODULE_DIR_ . $this->module->name,
+            'moduleFullDir' => _PS_MODULE_DIR_ . $this->module->name,
             'isShowModalConfiguration' => (int) Configuration::get(PaypalConfigurations::SHOW_MODAL_CONFIGURATION),
             'diagnosticPage' => $this->context->link->getAdminLink('AdminPaypalDiagnostic'),
             'loggerPage' => $this->context->link->getAdminLink('AdminPaypalProcessLogger'),

--- a/controllers/admin/AdminPaypalConfigurationController.php
+++ b/controllers/admin/AdminPaypalConfigurationController.php
@@ -268,6 +268,7 @@ class AdminPaypalConfigurationController extends \ModuleAdminController
             }
 
             $template = $this->context->smarty->createTemplate($tmpPath);
+            $template->assign('moduleFullDir', _PS_MODULE_DIR_ . $this->module->name);
             $template->assign('form', $desc);
             $template->assign('isModal', (int) Tools::getValue('isModal'));
             $responseBody['forms'][$desc['id_form']] = $template->fetch();
@@ -288,6 +289,7 @@ class AdminPaypalConfigurationController extends \ModuleAdminController
             'isConfigured' => $this->method->isConfigured(),
             'isSandbox' => $this->method->isSandbox(),
             'merchantId' => $this->method->getMerchantId(),
+            'moduleFullDir' => _PS_MODULE_DIR_ . $this->module->name,
         ]);
         $response->setData([
             'success' => true,

--- a/views/templates/admin/_partials/dashboard.tpl
+++ b/views/templates/admin/_partials/dashboard.tpl
@@ -24,7 +24,7 @@
  *
  *}
 <div class="row" data-dashboard>
-    {include file="module:paypal/views/templates/admin/_partials/welcome-board.tpl"}
+    {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/welcome-board.tpl"}
   <div class="col col-md-6 mt-4">
     <div class="card h-100">
       <div class="card-header">
@@ -32,7 +32,7 @@
       </div>
       <div class="card-body" technical-checklist-container>
         {include
-          file="module:paypal/views/templates/admin/_partials/statusBlock.tpl"
+          file=$moduleFullDir|cat:"/views/templates/admin/_partials/statusBlock.tpl"
           vars=$technicalChecklistForm.fields.technicalChecklist.set
         }
       </div>
@@ -45,7 +45,7 @@
       </div>
       <div class="card-body" feature-checklist-container>
         {include
-          file="module:paypal/views/templates/admin/_partials/featureChecklist.tpl"
+          file=$moduleFullDir|cat:"/views/templates/admin/_partials/featureChecklist.tpl"
           vars=$featureChecklistForm.fields.featureChecklist.set
         }
       </div>

--- a/views/templates/admin/_partials/featureChecklist.tpl
+++ b/views/templates/admin/_partials/featureChecklist.tpl
@@ -29,7 +29,7 @@
       {if isset($vars.isBnplEnabled)}
         <li class="d-flex align-items-center mb-1">
           {include
-            file="module:paypal/views/templates/admin/_partials/icon-status.tpl"
+            file=$moduleFullDir|cat:"/views/templates/admin/_partials/icon-status.tpl"
             isSuccess=$vars.isBnplEnabled|default:false
           }
           {if $vars.isBnplEnabled}
@@ -42,7 +42,7 @@
 
       <li class="d-flex align-items-center mb-1">
         {include
-          file="module:paypal/views/templates/admin/_partials/icon-status.tpl"
+          file=$moduleFullDir|cat:"/views/templates/admin/_partials/icon-status.tpl"
           isSuccess=$vars.isShortcutCustomized|default:false
         }
         {if $vars.isShortcutCustomized|default:false}
@@ -55,7 +55,7 @@
       {if isset($vars.isCreditCardEnabled)}
         <li class="d-flex align-items-center mb-1">
             {include
-            file="module:paypal/views/templates/admin/_partials/icon-status.tpl"
+            file=$moduleFullDir|cat:"/views/templates/admin/_partials/icon-status.tpl"
             isSuccess=$vars.isCreditCardEnabled
             }
 
@@ -66,7 +66,7 @@
       {if isset($vars.isPuiEnabled)}
         <li class="d-flex align-items-center mb-1">
           {include
-            file="module:paypal/views/templates/admin/_partials/icon-status.tpl"
+            file=$moduleFullDir|cat:"/views/templates/admin/_partials/icon-status.tpl"
             isSuccess=$vars.isPuiEnabled|default:false
           }
           {if $vars.isPuiEnabled}
@@ -79,7 +79,7 @@
 
       <li class="d-flex align-items-center mb-1">
         {include
-          file="module:paypal/views/templates/admin/_partials/icon-status.tpl"
+          file=$moduleFullDir|cat:"/views/templates/admin/_partials/icon-status.tpl"
           isSuccess=true
         }
         {if $vars.isOrderStatusCustomized|default:false}
@@ -91,7 +91,7 @@
 
       <li class="d-flex align-items-center">
         {include
-          file="module:paypal/views/templates/admin/_partials/icon-status.tpl"
+          file=$moduleFullDir|cat:"/views/templates/admin/_partials/icon-status.tpl"
           isSuccess=$vars.isShowPaypalBenefits|default:false
         }
           {l s='PayPal benefits enabled' mod='paypal'}
@@ -99,7 +99,7 @@
 
       <li class="d-flex align-items-center">
           {include
-          file="module:paypal/views/templates/admin/_partials/icon-status.tpl"
+          file=$moduleFullDir|cat:"/views/templates/admin/_partials/icon-status.tpl"
           isSuccess=true
           }
           {l s='Tracking enabled' mod='paypal'}

--- a/views/templates/admin/_partials/forms/form.tpl
+++ b/views/templates/admin/_partials/forms/form.tpl
@@ -30,7 +30,7 @@
     {foreach from=$form.fields item=field}
       {if $field.name|default:false}
         {block name='form_field'}
-          {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$field}
+          {include file="../form-fields.tpl" field=$field}
         {/block}
       {/if}
     {/foreach}

--- a/views/templates/admin/_partials/forms/form.tpl
+++ b/views/templates/admin/_partials/forms/form.tpl
@@ -30,7 +30,7 @@
     {foreach from=$form.fields item=field}
       {if $field.name|default:false}
         {block name='form_field'}
-          {include file="module:paypal/views/templates/admin/_partials/form-fields.tpl" field=$field}
+          {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$field}
         {/block}
       {/if}
     {/foreach}

--- a/views/templates/admin/_partials/forms/pp_account_form.tpl
+++ b/views/templates/admin/_partials/forms/pp_account_form.tpl
@@ -23,10 +23,12 @@
  *  @copyright PayPal
  *
  *}
-{extends file=$moduleFullDir|cat:"/views/templates/admin/_partials/forms/form.tpl"}
 {assign var="isModal" value=$isModal|default:false}
 
-{block name='form_content'}
+
+<form id="{$form.id_form}" class="mt-4 {[
+  'form-modal' => $isModal
+]|classnames}" data-form-configuration {block name='form_attributes'}{/block}>
   {foreach from=$form.fields key=fieldKey item=field}
     {if $fieldKey == 'account_form'}
       {assign var="isShowCredentials" value=in_array($field.set.country_iso, ['MX', 'BR', 'JP', 'IN'])}
@@ -34,7 +36,7 @@
       <input type="hidden" name="is_configured_live" value="{$field.set.is_configured_live}">
       <input type="hidden" name="is_configured_sandbox" value="{$field.set.is_configured_sandbox}">
 
-      {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=[
+      {include file="../form-fields.tpl" field=[
         'type' => 'select',
         'name' => 'mode',
         'value' => $field.set.mode|default:'',
@@ -54,21 +56,21 @@
 
       <div credential-section>
         <div live-section style="display: none">
-            {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=[
+            {include file="../form-fields.tpl" field=[
             'type' => 'text',
             'name' => 'paypal_clientid_live',
             'label' => "{l s='Client\’s ID' mod='paypal'}",
             'variant' => 'primary',
             'value' => $field.set.paypal_clientid_live|default:''
             ]}
-            {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=[
+            {include file="../form-fields.tpl" field=[
             'type' => 'text',
             'name' => 'paypal_secret_live',
             'label' => "{l s='Client\’s secret' mod='paypal'}",
             'variant' => 'primary',
             'value' => $field.set.paypal_secret_live|default:''
             ]}
-            {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=[
+            {include file="../form-fields.tpl" field=[
             'type' => 'text',
             'name' => 'merchant_id_live',
             'value' => $field.set.merchant_id_live|default:'',
@@ -78,21 +80,21 @@
         </div>
 
         <div sandbox-section style="display: none">
-            {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=[
+            {include file="../form-fields.tpl" field=[
             'type' => 'text',
             'name' => 'paypal_clientid_sandbox',
             'label' => "{l s='Client\’s ID' mod='paypal'}",
             'variant' => 'primary',
             'value' => $field.set.paypal_clientid_sandbox|default:''
             ]}
-            {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=[
+            {include file="../form-fields.tpl" field=[
             'type' => 'text',
             'name' => 'paypal_secret_sandbox',
             'label' => "{l s='Client\’s secret' mod='paypal'}",
             'variant' => 'primary',
             'value' => $field.set.paypal_secret_sandbox|default:''
             ]}
-            {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=[
+            {include file="../form-fields.tpl" field=[
             'type' => 'text',
             'name' => 'merchant_id_sandbox',
             'value' => $field.set.merchant_id_sandbox|default:'',
@@ -222,8 +224,6 @@
 
   </script>
 
-{/block}
-
 {block name='form_footer_buttons'}
   {if $isModal}
     <div>
@@ -239,3 +239,4 @@
   {/if}
   <button save-form class="btn btn-secondary ml-auto" name={$form.submit.name}>{$form.submit.title}</button>
 {/block}
+</form>

--- a/views/templates/admin/_partials/forms/pp_account_form.tpl
+++ b/views/templates/admin/_partials/forms/pp_account_form.tpl
@@ -23,7 +23,7 @@
  *  @copyright PayPal
  *
  *}
-{extends file="module:paypal/views/templates/admin/_partials/forms/form.tpl"}
+{extends file=$moduleFullDir|cat:"/views/templates/admin/_partials/forms/form.tpl"}
 {assign var="isModal" value=$isModal|default:false}
 
 {block name='form_content'}
@@ -34,7 +34,7 @@
       <input type="hidden" name="is_configured_live" value="{$field.set.is_configured_live}">
       <input type="hidden" name="is_configured_sandbox" value="{$field.set.is_configured_sandbox}">
 
-      {include file="module:paypal/views/templates/admin/_partials/form-fields.tpl" field=[
+      {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=[
         'type' => 'select',
         'name' => 'mode',
         'value' => $field.set.mode|default:'',
@@ -54,21 +54,21 @@
 
       <div credential-section>
         <div live-section style="display: none">
-            {include file="module:paypal/views/templates/admin/_partials/form-fields.tpl" field=[
+            {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=[
             'type' => 'text',
             'name' => 'paypal_clientid_live',
             'label' => "{l s='Client\’s ID' mod='paypal'}",
             'variant' => 'primary',
             'value' => $field.set.paypal_clientid_live|default:''
             ]}
-            {include file="module:paypal/views/templates/admin/_partials/form-fields.tpl" field=[
+            {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=[
             'type' => 'text',
             'name' => 'paypal_secret_live',
             'label' => "{l s='Client\’s secret' mod='paypal'}",
             'variant' => 'primary',
             'value' => $field.set.paypal_secret_live|default:''
             ]}
-            {include file="module:paypal/views/templates/admin/_partials/form-fields.tpl" field=[
+            {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=[
             'type' => 'text',
             'name' => 'merchant_id_live',
             'value' => $field.set.merchant_id_live|default:'',
@@ -78,21 +78,21 @@
         </div>
 
         <div sandbox-section style="display: none">
-            {include file="module:paypal/views/templates/admin/_partials/form-fields.tpl" field=[
+            {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=[
             'type' => 'text',
             'name' => 'paypal_clientid_sandbox',
             'label' => "{l s='Client\’s ID' mod='paypal'}",
             'variant' => 'primary',
             'value' => $field.set.paypal_clientid_sandbox|default:''
             ]}
-            {include file="module:paypal/views/templates/admin/_partials/form-fields.tpl" field=[
+            {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=[
             'type' => 'text',
             'name' => 'paypal_secret_sandbox',
             'label' => "{l s='Client\’s secret' mod='paypal'}",
             'variant' => 'primary',
             'value' => $field.set.paypal_secret_sandbox|default:''
             ]}
-            {include file="module:paypal/views/templates/admin/_partials/form-fields.tpl" field=[
+            {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=[
             'type' => 'text',
             'name' => 'merchant_id_sandbox',
             'value' => $field.set.merchant_id_sandbox|default:'',

--- a/views/templates/admin/_partials/forms/pp_checkout_form.tpl
+++ b/views/templates/admin/_partials/forms/pp_checkout_form.tpl
@@ -23,7 +23,7 @@
  *  @copyright PayPal
  *
  *}
-{extends file="module:paypal/views/templates/admin/_partials/forms/form.tpl"}
+{extends file=$moduleFullDir|cat:"/views/templates/admin/_partials/forms/form.tpl"}
 
 {assign var="fieldsExpressCheckoutShortcut" value=['PAYPAL_EXPRESS_CHECKOUT_SHORTCUT', 'PAYPAL_EXPRESS_CHECKOUT_SHORTCUT_CART', 'PAYPAL_EXPRESS_CHECKOUT_SHORTCUT_SIGNUP']}
 
@@ -31,7 +31,7 @@
 
     {foreach from=$form.fields item=field}
         {if $field.name|in_array:['PAYPAL_API_INTENT', 'PAYPAL_EXPRESS_CHECKOUT_IN_CONTEXT']}
-            {include file="module:paypal/views/templates/admin/_partials/form-fields.tpl" field=$field }
+            {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$field }
         {/if}
     {/foreach}
 
@@ -41,7 +41,7 @@
       <div class="row no-gutters">
           {foreach from=$form.fields item=field}
               {if $field.name|in_array:$fieldsExpressCheckoutShortcut}
-                  {include file="module:paypal/views/templates/admin/_partials/form-fields.tpl" field=$field }
+                  {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$field }
               {/if}
           {/foreach}
       </div>
@@ -53,7 +53,7 @@
             {if $field.name == 'PAYPAL_MOVE_BUTTON_AT_END' && $isShowModalConfiguration|default:false}
                 {continue}
             {/if}
-            {include file="module:paypal/views/templates/admin/_partials/form-fields.tpl" field=$field }
+            {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$field }
         {/if}
     {/foreach}
 

--- a/views/templates/admin/_partials/forms/pp_checkout_form.tpl
+++ b/views/templates/admin/_partials/forms/pp_checkout_form.tpl
@@ -23,15 +23,13 @@
  *  @copyright PayPal
  *
  *}
-{extends file=$moduleFullDir|cat:"/views/templates/admin/_partials/forms/form.tpl"}
-
-{assign var="fieldsExpressCheckoutShortcut" value=['PAYPAL_EXPRESS_CHECKOUT_SHORTCUT', 'PAYPAL_EXPRESS_CHECKOUT_SHORTCUT_CART', 'PAYPAL_EXPRESS_CHECKOUT_SHORTCUT_SIGNUP']}
+{extends file="./form.tpl"}
 
 {block name='form_content'}
 
     {foreach from=$form.fields item=field}
         {if $field.name|in_array:['PAYPAL_API_INTENT', 'PAYPAL_EXPRESS_CHECKOUT_IN_CONTEXT']}
-            {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$field }
+            {include file="../form-fields.tpl" field=$field }
         {/if}
     {/foreach}
 
@@ -40,8 +38,8 @@
     <div class="col-9">
       <div class="row no-gutters">
           {foreach from=$form.fields item=field}
-              {if $field.name|in_array:$fieldsExpressCheckoutShortcut}
-                  {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$field }
+              {if $field.name|in_array:['PAYPAL_EXPRESS_CHECKOUT_SHORTCUT', 'PAYPAL_EXPRESS_CHECKOUT_SHORTCUT_CART', 'PAYPAL_EXPRESS_CHECKOUT_SHORTCUT_SIGNUP']}
+                  {include file="../form-fields.tpl" field=$field }
               {/if}
           {/foreach}
       </div>
@@ -53,7 +51,7 @@
             {if $field.name == 'PAYPAL_MOVE_BUTTON_AT_END' && $isShowModalConfiguration|default:false}
                 {continue}
             {/if}
-            {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$field }
+            {include file="../form-fields.tpl" field=$field }
         {/if}
     {/foreach}
 

--- a/views/templates/admin/_partials/forms/pp_installment_form.tpl
+++ b/views/templates/admin/_partials/forms/pp_installment_form.tpl
@@ -23,16 +23,16 @@
  *  @copyright PayPal
  *
  *}
-{extends file=$moduleFullDir|cat:"/views/templates/admin/_partials/forms/form.tpl"}
-
-{assign var="fieldsInstallmentBNPL" value=['PAYPAL_BNPL_PRODUCT_PAGE', 'PAYPAL_BNPL_PAYMENT_STEP_PAGE', 'PAYPAL_BNPL_CART_PAGE', 'PAYPAL_BNPL_CHECKOUT_PAGE']}
-{assign var="fieldsInstallment" value=['PAYPAL_INSTALLMENT_PRODUCT_PAGE', 'PAYPAL_INSTALLMENT_HOME_PAGE', 'PAYPAL_INSTALLMENT_CATEGORY_PAGE', 'PAYPAL_INSTALLMENT_CART_PAGE', 'PAYPAL_INSTALLMENT_CHECKOUT_PAGE']}
-{assign var="dynamicField" value=$form.fields.PAYPAL_ENABLE_BNPL|default:false}
-{assign var="dynamicFieldBanner" value=$form.fields.PAYPAL_ENABLE_INSTALLMENT|default:false}
+{extends file="./form.tpl"}
 
 {block name='form_content'}
+
+  {assign var="fieldsInstallmentBNPL" value=['PAYPAL_BNPL_PRODUCT_PAGE', 'PAYPAL_BNPL_PAYMENT_STEP_PAGE', 'PAYPAL_BNPL_CART_PAGE', 'PAYPAL_BNPL_CHECKOUT_PAGE']}
+  {assign var="fieldsInstallment" value=['PAYPAL_INSTALLMENT_PRODUCT_PAGE', 'PAYPAL_INSTALLMENT_HOME_PAGE', 'PAYPAL_INSTALLMENT_CATEGORY_PAGE', 'PAYPAL_INSTALLMENT_CART_PAGE', 'PAYPAL_INSTALLMENT_CHECKOUT_PAGE']}
+  {assign var="dynamicField" value=$form.fields.PAYPAL_ENABLE_BNPL|default:false}
+  {assign var="dynamicFieldBanner" value=$form.fields.PAYPAL_ENABLE_INSTALLMENT|default:false}
   {if $dynamicField}
-    {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$form.fields.PAYPAL_ENABLE_BNPL dynamicField=$dynamicField}
+    {include file="../form-fields.tpl" field=$form.fields.PAYPAL_ENABLE_BNPL dynamicField=$dynamicField}
   {/if}
 
   <div class="form-group row {[
@@ -43,14 +43,14 @@
       <div class="row no-gutters">
         {foreach from=$form.fields item=field}
           {if $field.name|in_array:$fieldsInstallmentBNPL}
-            {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$field}
+            {include file="../form-fields.tpl" field=$field}
           {/if}
         {/foreach}
       </div>
     </div>
   </div>
 
-  {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$form.fields.PAYPAL_ENABLE_INSTALLMENT dynamicField=$dynamicFieldBanner}
+  {include file="../form-fields.tpl" field=$form.fields.PAYPAL_ENABLE_INSTALLMENT dynamicField=$dynamicFieldBanner}
 
   <div class="form-group row {[
     'd-none' => $dynamicFieldBanner && !$dynamicFieldBanner.value
@@ -60,7 +60,7 @@
       <div class="row no-gutters">
         {foreach from=$form.fields item=field}
           {if $field.name|in_array:$fieldsInstallment}
-            {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$field}
+            {include file="../form-fields.tpl" field=$field}
           {/if}
         {/foreach}
       </div>
@@ -70,12 +70,12 @@
     <div class="{[
     'd-none' => $dynamicFieldBanner && !$dynamicFieldBanner.value
     ]|classnames}" {if $dynamicFieldBanner.name|default:false}group-name="{$dynamicFieldBanner.name}"{/if}>
-        {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$form.fields.PAYPAL_ADVANCED_OPTIONS_INSTALLMENT dynamicField=$form.fields.PAYPAL_ADVANCED_OPTIONS_INSTALLMENT}
+        {include file="../form-fields.tpl" field=$form.fields.PAYPAL_ADVANCED_OPTIONS_INSTALLMENT dynamicField=$form.fields.PAYPAL_ADVANCED_OPTIONS_INSTALLMENT}
 
-        {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$form.fields.PAYPAL_INSTALLMENT_COLOR withColor=true dynamicField=$form.fields.PAYPAL_ADVANCED_OPTIONS_INSTALLMENT}
+        {include file="../form-fields.tpl" field=$form.fields.PAYPAL_INSTALLMENT_COLOR withColor=true dynamicField=$form.fields.PAYPAL_ADVANCED_OPTIONS_INSTALLMENT}
 
         {if isset($form.fields.widget_code)}
-            {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$form.fields.widget_code dynamicField=$form.fields.PAYPAL_ADVANCED_OPTIONS_INSTALLMENT}
+            {include file="../form-fields.tpl" field=$form.fields.widget_code dynamicField=$form.fields.PAYPAL_ADVANCED_OPTIONS_INSTALLMENT}
         {/if}
     </div>
 

--- a/views/templates/admin/_partials/forms/pp_installment_form.tpl
+++ b/views/templates/admin/_partials/forms/pp_installment_form.tpl
@@ -23,7 +23,7 @@
  *  @copyright PayPal
  *
  *}
-{extends file="module:paypal/views/templates/admin/_partials/forms/form.tpl"}
+{extends file=$moduleFullDir|cat:"/views/templates/admin/_partials/forms/form.tpl"}
 
 {assign var="fieldsInstallmentBNPL" value=['PAYPAL_BNPL_PRODUCT_PAGE', 'PAYPAL_BNPL_PAYMENT_STEP_PAGE', 'PAYPAL_BNPL_CART_PAGE', 'PAYPAL_BNPL_CHECKOUT_PAGE']}
 {assign var="fieldsInstallment" value=['PAYPAL_INSTALLMENT_PRODUCT_PAGE', 'PAYPAL_INSTALLMENT_HOME_PAGE', 'PAYPAL_INSTALLMENT_CATEGORY_PAGE', 'PAYPAL_INSTALLMENT_CART_PAGE', 'PAYPAL_INSTALLMENT_CHECKOUT_PAGE']}
@@ -32,7 +32,7 @@
 
 {block name='form_content'}
   {if $dynamicField}
-    {include file="module:paypal/views/templates/admin/_partials/form-fields.tpl" field=$form.fields.PAYPAL_ENABLE_BNPL dynamicField=$dynamicField}
+    {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$form.fields.PAYPAL_ENABLE_BNPL dynamicField=$dynamicField}
   {/if}
 
   <div class="form-group row {[
@@ -43,14 +43,14 @@
       <div class="row no-gutters">
         {foreach from=$form.fields item=field}
           {if $field.name|in_array:$fieldsInstallmentBNPL}
-            {include file="module:paypal/views/templates/admin/_partials/form-fields.tpl" field=$field}
+            {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$field}
           {/if}
         {/foreach}
       </div>
     </div>
   </div>
 
-  {include file="module:paypal/views/templates/admin/_partials/form-fields.tpl" field=$form.fields.PAYPAL_ENABLE_INSTALLMENT dynamicField=$dynamicFieldBanner}
+  {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$form.fields.PAYPAL_ENABLE_INSTALLMENT dynamicField=$dynamicFieldBanner}
 
   <div class="form-group row {[
     'd-none' => $dynamicFieldBanner && !$dynamicFieldBanner.value
@@ -60,7 +60,7 @@
       <div class="row no-gutters">
         {foreach from=$form.fields item=field}
           {if $field.name|in_array:$fieldsInstallment}
-            {include file="module:paypal/views/templates/admin/_partials/form-fields.tpl" field=$field}
+            {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$field}
           {/if}
         {/foreach}
       </div>
@@ -70,12 +70,12 @@
     <div class="{[
     'd-none' => $dynamicFieldBanner && !$dynamicFieldBanner.value
     ]|classnames}" {if $dynamicFieldBanner.name|default:false}group-name="{$dynamicFieldBanner.name}"{/if}>
-        {include file="module:paypal/views/templates/admin/_partials/form-fields.tpl" field=$form.fields.PAYPAL_ADVANCED_OPTIONS_INSTALLMENT dynamicField=$form.fields.PAYPAL_ADVANCED_OPTIONS_INSTALLMENT}
+        {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$form.fields.PAYPAL_ADVANCED_OPTIONS_INSTALLMENT dynamicField=$form.fields.PAYPAL_ADVANCED_OPTIONS_INSTALLMENT}
 
-        {include file="module:paypal/views/templates/admin/_partials/form-fields.tpl" field=$form.fields.PAYPAL_INSTALLMENT_COLOR withColor=true dynamicField=$form.fields.PAYPAL_ADVANCED_OPTIONS_INSTALLMENT}
+        {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$form.fields.PAYPAL_INSTALLMENT_COLOR withColor=true dynamicField=$form.fields.PAYPAL_ADVANCED_OPTIONS_INSTALLMENT}
 
         {if isset($form.fields.widget_code)}
-            {include file="module:paypal/views/templates/admin/_partials/form-fields.tpl" field=$form.fields.widget_code dynamicField=$form.fields.PAYPAL_ADVANCED_OPTIONS_INSTALLMENT}
+            {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$form.fields.widget_code dynamicField=$form.fields.PAYPAL_ADVANCED_OPTIONS_INSTALLMENT}
         {/if}
     </div>
 

--- a/views/templates/admin/_partials/forms/pp_order_status_form.tpl
+++ b/views/templates/admin/_partials/forms/pp_order_status_form.tpl
@@ -23,14 +23,14 @@
  *  @copyright PayPal
  *
  *}
-{extends file=$moduleFullDir|cat:"/views/templates/admin/_partials/forms/form.tpl"}
-{assign var="dynamicField" value=$form.fields.PAYPAL_CUSTOMIZE_ORDER_STATUS}
+{extends file="./form.tpl"}
 
 {block name='form_field'}
+    {assign var="dynamicField" value=$form.fields.PAYPAL_CUSTOMIZE_ORDER_STATUS}
     {if $field.name == 'PAYPAL_ENABLE_WEBHOOK'}
-        {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$field dynamicField=false}
+        {include file="../form-fields.tpl" field=$field dynamicField=false}
     {else}
-        {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$field dynamicField=$dynamicField}
+        {include file="../form-fields.tpl" field=$field dynamicField=$dynamicField}
     {/if}
 
 {/block}

--- a/views/templates/admin/_partials/forms/pp_order_status_form.tpl
+++ b/views/templates/admin/_partials/forms/pp_order_status_form.tpl
@@ -23,14 +23,14 @@
  *  @copyright PayPal
  *
  *}
-{extends file="module:paypal/views/templates/admin/_partials/forms/form.tpl"}
+{extends file=$moduleFullDir|cat:"/views/templates/admin/_partials/forms/form.tpl"}
 {assign var="dynamicField" value=$form.fields.PAYPAL_CUSTOMIZE_ORDER_STATUS}
 
 {block name='form_field'}
     {if $field.name == 'PAYPAL_ENABLE_WEBHOOK'}
-        {include file="module:paypal/views/templates/admin/_partials/form-fields.tpl" field=$field dynamicField=false}
+        {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$field dynamicField=false}
     {else}
-        {include file="module:paypal/views/templates/admin/_partials/form-fields.tpl" field=$field dynamicField=$dynamicField}
+        {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$field dynamicField=$dynamicField}
     {/if}
 
 {/block}

--- a/views/templates/admin/_partials/forms/pp_shortcut_configuration_form.tpl
+++ b/views/templates/admin/_partials/forms/pp_shortcut_configuration_form.tpl
@@ -23,20 +23,20 @@
  *  @copyright PayPal
  *
  *}
-{extends file="module:paypal/views/templates/admin/_partials/forms/form.tpl"}
+{extends file=$moduleFullDir|cat:"/views/templates/admin/_partials/forms/form.tpl"}
 {assign var="fieldsButtonConfiguration" value=['PAYPAL_EXPRESS_CHECKOUT_SHORTCUT_STYLE_COLOR_CART', 'PAYPAL_EXPRESS_CHECKOUT_SHORTCUT_STYLE_SHAPE_CART', 'PAYPAL_EXPRESS_CHECKOUT_SHORTCUT_STYLE_WIDTH_CART', 'PAYPAL_EXPRESS_CHECKOUT_SHORTCUT_STYLE_HEIGHT_CART', 'PAYPAL_EXPRESS_CHECKOUT_SHORTCUT_STYLE_LABEL_CART']}
 {assign var="dynamicField" value=$form.fields.PAYPAL_EXPRESS_CHECKOUT_CUSTOMIZE_SHORTCUT_STYLE}
 
 {block name='form_content'}
     {if isset($form.fields.PAYPAL_EXPRESS_CHECKOUT_CUSTOMIZE_SHORTCUT_STYLE)}
-        {include file="module:paypal/views/templates/admin/_partials/form-fields.tpl" field=$form.fields.PAYPAL_EXPRESS_CHECKOUT_CUSTOMIZE_SHORTCUT_STYLE dynamicField=$dynamicField}
+        {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$form.fields.PAYPAL_EXPRESS_CHECKOUT_CUSTOMIZE_SHORTCUT_STYLE dynamicField=$dynamicField}
     {/if}
 
     <div group-name="{$dynamicField.name}" {if !$form.fields.PAYPAL_EXPRESS_CHECKOUT_CUSTOMIZE_SHORTCUT_STYLE.value|default:false}class="d-none"{/if}>
         {if isset($form.fields.PAYPAL_EXPRESS_CHECKOUT_DISPLAY_MODE_CART)}
           <div class="h6">{l s='Cart page' mod='paypal'}</div>
           <hr>
-            {include file="module:paypal/views/templates/admin/_partials/shortcut_configuration_section.tpl"
+            {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/shortcut_configuration_section.tpl"
               displayMode=$form.fields.PAYPAL_EXPRESS_CHECKOUT_DISPLAY_MODE_CART
               hooks=$form.fields.PAYPAL_EXPRESS_CHECKOUT_SHORTCUT_HOOK_CART
               widget_type='cart'
@@ -52,7 +52,7 @@
         {if isset($form.fields.PAYPAL_EXPRESS_CHECKOUT_DISPLAY_MODE_PRODUCT)}
           <div class="h6">{l s='Product page' mod='paypal'}</div>
           <hr>
-            {include file="module:paypal/views/templates/admin/_partials/shortcut_configuration_section.tpl"
+            {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/shortcut_configuration_section.tpl"
               displayMode=$form.fields.PAYPAL_EXPRESS_CHECKOUT_DISPLAY_MODE_PRODUCT
               hooks=$form.fields.PAYPAL_EXPRESS_CHECKOUT_SHORTCUT_HOOK_PRODUCT
               widget_type='product'
@@ -68,7 +68,7 @@
         {if isset($form.fields.PAYPAL_EXPRESS_CHECKOUT_DISPLAY_MODE_SIGNUP)}
           <div class="h6">{l s='Signup page' mod='paypal'}</div>
           <hr>
-            {include file="module:paypal/views/templates/admin/_partials/shortcut_configuration_section.tpl"
+            {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/shortcut_configuration_section.tpl"
               displayMode=$form.fields.PAYPAL_EXPRESS_CHECKOUT_DISPLAY_MODE_SIGNUP
               widget_type='signup'
               color=$form.fields.PAYPAL_EXPRESS_CHECKOUT_SHORTCUT_STYLE_COLOR_SIGNUP

--- a/views/templates/admin/_partials/forms/pp_shortcut_configuration_form.tpl
+++ b/views/templates/admin/_partials/forms/pp_shortcut_configuration_form.tpl
@@ -23,20 +23,20 @@
  *  @copyright PayPal
  *
  *}
-{extends file=$moduleFullDir|cat:"/views/templates/admin/_partials/forms/form.tpl"}
-{assign var="fieldsButtonConfiguration" value=['PAYPAL_EXPRESS_CHECKOUT_SHORTCUT_STYLE_COLOR_CART', 'PAYPAL_EXPRESS_CHECKOUT_SHORTCUT_STYLE_SHAPE_CART', 'PAYPAL_EXPRESS_CHECKOUT_SHORTCUT_STYLE_WIDTH_CART', 'PAYPAL_EXPRESS_CHECKOUT_SHORTCUT_STYLE_HEIGHT_CART', 'PAYPAL_EXPRESS_CHECKOUT_SHORTCUT_STYLE_LABEL_CART']}
-{assign var="dynamicField" value=$form.fields.PAYPAL_EXPRESS_CHECKOUT_CUSTOMIZE_SHORTCUT_STYLE}
+{extends file="./form.tpl"}
 
 {block name='form_content'}
+  {assign var="fieldsButtonConfiguration" value=['PAYPAL_EXPRESS_CHECKOUT_SHORTCUT_STYLE_COLOR_CART', 'PAYPAL_EXPRESS_CHECKOUT_SHORTCUT_STYLE_SHAPE_CART', 'PAYPAL_EXPRESS_CHECKOUT_SHORTCUT_STYLE_WIDTH_CART', 'PAYPAL_EXPRESS_CHECKOUT_SHORTCUT_STYLE_HEIGHT_CART', 'PAYPAL_EXPRESS_CHECKOUT_SHORTCUT_STYLE_LABEL_CART']}
+  {assign var="dynamicField" value=$form.fields.PAYPAL_EXPRESS_CHECKOUT_CUSTOMIZE_SHORTCUT_STYLE}
     {if isset($form.fields.PAYPAL_EXPRESS_CHECKOUT_CUSTOMIZE_SHORTCUT_STYLE)}
-        {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$form.fields.PAYPAL_EXPRESS_CHECKOUT_CUSTOMIZE_SHORTCUT_STYLE dynamicField=$dynamicField}
+        {include file="../form-fields.tpl" field=$form.fields.PAYPAL_EXPRESS_CHECKOUT_CUSTOMIZE_SHORTCUT_STYLE dynamicField=$dynamicField}
     {/if}
 
     <div group-name="{$dynamicField.name}" {if !$form.fields.PAYPAL_EXPRESS_CHECKOUT_CUSTOMIZE_SHORTCUT_STYLE.value|default:false}class="d-none"{/if}>
         {if isset($form.fields.PAYPAL_EXPRESS_CHECKOUT_DISPLAY_MODE_CART)}
           <div class="h6">{l s='Cart page' mod='paypal'}</div>
           <hr>
-            {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/shortcut_configuration_section.tpl"
+            {include file="../shortcut_configuration_section.tpl"
               displayMode=$form.fields.PAYPAL_EXPRESS_CHECKOUT_DISPLAY_MODE_CART
               hooks=$form.fields.PAYPAL_EXPRESS_CHECKOUT_SHORTCUT_HOOK_CART
               widget_type='cart'
@@ -52,7 +52,7 @@
         {if isset($form.fields.PAYPAL_EXPRESS_CHECKOUT_DISPLAY_MODE_PRODUCT)}
           <div class="h6">{l s='Product page' mod='paypal'}</div>
           <hr>
-            {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/shortcut_configuration_section.tpl"
+            {include file="../shortcut_configuration_section.tpl"
               displayMode=$form.fields.PAYPAL_EXPRESS_CHECKOUT_DISPLAY_MODE_PRODUCT
               hooks=$form.fields.PAYPAL_EXPRESS_CHECKOUT_SHORTCUT_HOOK_PRODUCT
               widget_type='product'
@@ -68,7 +68,7 @@
         {if isset($form.fields.PAYPAL_EXPRESS_CHECKOUT_DISPLAY_MODE_SIGNUP)}
           <div class="h6">{l s='Signup page' mod='paypal'}</div>
           <hr>
-            {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/shortcut_configuration_section.tpl"
+            {include file="../shortcut_configuration_section.tpl"
               displayMode=$form.fields.PAYPAL_EXPRESS_CHECKOUT_DISPLAY_MODE_SIGNUP
               widget_type='signup'
               color=$form.fields.PAYPAL_EXPRESS_CHECKOUT_SHORTCUT_STYLE_COLOR_SIGNUP

--- a/views/templates/admin/_partials/forms/pp_tracking_form.tpl
+++ b/views/templates/admin/_partials/forms/pp_tracking_form.tpl
@@ -23,12 +23,12 @@
  *  @copyright PayPal
  *
  *}
-{extends file=$moduleFullDir|cat:"/views/templates/admin/_partials/forms/form.tpl"}
+{extends file="./form.tpl"}
 
 {block name='form_content'}
   {foreach from=$form.fields item=field key=key}
     {if $field.name|default:false && $field.type == 'select'}
-      {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$field}
+      {include file="../form-fields.tpl" field=$field}
     {elseif $key == 'carrier_map'}
       <div class="form-group row pt-4">
         <label class="form-control-label form-control-label-check col-3" for="PAYPAL_CARRIER_MAP">{$field.label}</label>
@@ -52,7 +52,7 @@
                       ]}
                     {/foreach}
                     {include
-                      file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl"
+                      file="../form-fields.tpl"
                       field=[
                         'type' => 'select',
                         'name' => 'carrier_map[]',

--- a/views/templates/admin/_partials/forms/pp_tracking_form.tpl
+++ b/views/templates/admin/_partials/forms/pp_tracking_form.tpl
@@ -23,12 +23,12 @@
  *  @copyright PayPal
  *
  *}
-{extends file="module:paypal/views/templates/admin/_partials/forms/form.tpl"}
+{extends file=$moduleFullDir|cat:"/views/templates/admin/_partials/forms/form.tpl"}
 
 {block name='form_content'}
   {foreach from=$form.fields item=field key=key}
     {if $field.name|default:false && $field.type == 'select'}
-      {include file="module:paypal/views/templates/admin/_partials/form-fields.tpl" field=$field}
+      {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$field}
     {elseif $key == 'carrier_map'}
       <div class="form-group row pt-4">
         <label class="form-control-label form-control-label-check col-3" for="PAYPAL_CARRIER_MAP">{$field.label}</label>
@@ -52,7 +52,7 @@
                       ]}
                     {/foreach}
                     {include
-                      file="module:paypal/views/templates/admin/_partials/form-fields.tpl"
+                      file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl"
                       field=[
                         'type' => 'select',
                         'name' => 'carrier_map[]',

--- a/views/templates/admin/_partials/modal-configuration.tpl
+++ b/views/templates/admin/_partials/modal-configuration.tpl
@@ -31,7 +31,7 @@
       <div class="card-body pb-0">
         <div class="row">
           <div class="col-6">
-            <img src="{$moduleDir|addslashes}/views/img/paypal.svg"  alt="paypal">
+            <img src="{$moduleFullDir|addslashes}/views/img/paypal.svg"  alt="paypal">
           </div>
           <div class="col-6 d-flex flex-column">
             <div class="progress">
@@ -44,21 +44,21 @@
       <div>
         <div data-step-content>
           {include
-            file="module:paypal/views/templates/admin/_partials/section.tpl"
+            file=$moduleFullDir|cat:"/views/templates/admin/_partials/section.tpl"
             form=$accountForm
             isModal=true
           }
         </div>
         <div class="d-none" data-step-content>
           {include
-            file="module:paypal/views/templates/admin/_partials/section.tpl"
+            file=$moduleFullDir|cat:"/views/templates/admin/_partials/section.tpl"
             form=$checkoutForm
             isModal=true
           }
         </div>
         <div class="d-none" data-step-content>
           {include
-            file="module:paypal/views/templates/admin/_partials/section.tpl"
+            file=$moduleFullDir|cat:"/views/templates/admin/_partials/section.tpl"
             form=$formInstallment
             sectionColFormClasses=' '
             sectionColInfoClasses=' '
@@ -67,21 +67,21 @@
         </div>
         <div class="d-none" data-step-content>
           {include
-            file="module:paypal/views/templates/admin/_partials/section.tpl"
+            file=$moduleFullDir|cat:"/views/templates/admin/_partials/section.tpl"
             form=$shortcutConfigurationForm
             isModal=true
           }
         </div>
         <div class="d-none" data-step-content>
           {include
-            file="module:paypal/views/templates/admin/_partials/section.tpl"
+            file=$moduleFullDir|cat:"/views/templates/admin/_partials/section.tpl"
             form=$orderStatusForm
             isModal=true
           }
         </div>
         <div class="d-none" data-step-content>
           {include
-            file="module:paypal/views/templates/admin/_partials/section.tpl"
+            file=$moduleFullDir|cat:"/views/templates/admin/_partials/section.tpl"
             form=$whiteListForm
             isModal=true
           }

--- a/views/templates/admin/_partials/modal-configuration.tpl
+++ b/views/templates/admin/_partials/modal-configuration.tpl
@@ -31,7 +31,7 @@
       <div class="card-body pb-0">
         <div class="row">
           <div class="col-6">
-            <img src="{$moduleFullDir|addslashes}/views/img/paypal.svg"  alt="paypal">
+            <img src="{$moduleDir|addslashes}/views/img/paypal.svg"  alt="paypal">
           </div>
           <div class="col-6 d-flex flex-column">
             <div class="progress">

--- a/views/templates/admin/_partials/modal-configuration.tpl
+++ b/views/templates/admin/_partials/modal-configuration.tpl
@@ -37,7 +37,7 @@
             <div class="progress">
               <div class="progress-bar" data-steps-progress role="progressbar" style="width: 0;" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100"></div>
             </div>
-            <span class="badge bg-warning text-primary ml-auto mt-4">{l s='Step :' mod='paypal'} <span data-badge-current-step>1</span> {l s='out of' mod='paypal'} 6</span>
+            <span class="badge bg-warning text-primary ml-auto mt-4">{l s='Step :' mod='paypal'} <span data-badge-current-step>1</span> {l s='out of' mod='paypal'} <span data-badge-max-step></span></span>
           </div>
         </div>
       </div>
@@ -56,15 +56,17 @@
             isModal=true
           }
         </div>
-        <div class="d-none" data-step-content>
-          {include
-            file=$moduleFullDir|cat:"/views/templates/admin/_partials/section.tpl"
-            form=$formInstallment
-            sectionColFormClasses=' '
-            sectionColInfoClasses=' '
-            isModal=true
-          }
-        </div>
+        {if isset($formInstallment)}
+          <div class="d-none" data-step-content>
+            {include
+              file=$moduleFullDir|cat:"/views/templates/admin/_partials/section.tpl"
+              form=$formInstallment
+              sectionColFormClasses=' '
+              sectionColInfoClasses=' '
+              isModal=true
+            }
+          </div>
+        {/if}
         <div class="d-none" data-step-content>
           {include
             file=$moduleFullDir|cat:"/views/templates/admin/_partials/section.tpl"

--- a/views/templates/admin/_partials/section.tpl
+++ b/views/templates/admin/_partials/section.tpl
@@ -46,9 +46,9 @@
       {/if}
         <div form-container="{$form.id_form}">
             {if $form.id_form != 'pp_white_list_form'}
-                {include file="module:paypal/views/templates/admin/_partials/forms/"|cat:$form.id_form|cat:".tpl" form=$form}
+                {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/forms/"|cat:$form.id_form|cat:".tpl" form=$form}
             {else}
-                {include file="module:paypal/views/templates/admin/_partials/forms/form.tpl" form=$form}
+                {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/forms/form.tpl" form=$form}
             {/if}
         </div>
      </div>

--- a/views/templates/admin/_partials/shortcut_configuration_section.tpl
+++ b/views/templates/admin/_partials/shortcut_configuration_section.tpl
@@ -25,15 +25,15 @@
  *}
 
 {if isset($displayMode) && $displayMode}
-    {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$displayMode dynamicField=false}
+    {include file="./form-fields.tpl" field=$displayMode dynamicField=false}
 {/if}
 
 {if isset($hooks) && $hooks}
-    {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$hooks dynamicField=false}
+    {include file="./form-fields.tpl" field=$hooks dynamicField=false}
 {/if}
 
 {if isset($widget_type) && $widget_type}
-    {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl"
+    {include file="./form-fields.tpl"
       field=[
           'label' => 'Widget code',
           'type' => 'widget-code',
@@ -55,11 +55,11 @@
   </div>
 
     {if isset($color) && $color}
-        {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$color dynamicField=false}
+        {include file="./form-fields.tpl" field=$color dynamicField=false}
     {/if}
 
     {if isset($shape) && $shape}
-        {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$shape dynamicField=false}
+        {include file="./form-fields.tpl" field=$shape dynamicField=false}
     {/if}
 
     {if isset($height) && isset($width) && $height && $width}
@@ -107,7 +107,7 @@
     {/if}
 
     {if isset($label) && $label}
-        {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$label dynamicField=false}
+        {include file="./form-fields.tpl" field=$label dynamicField=false}
     {/if}
 
 </div>

--- a/views/templates/admin/_partials/shortcut_configuration_section.tpl
+++ b/views/templates/admin/_partials/shortcut_configuration_section.tpl
@@ -25,15 +25,15 @@
  *}
 
 {if isset($displayMode) && $displayMode}
-    {include file="module:paypal/views/templates/admin/_partials/form-fields.tpl" field=$displayMode dynamicField=false}
+    {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$displayMode dynamicField=false}
 {/if}
 
 {if isset($hooks) && $hooks}
-    {include file="module:paypal/views/templates/admin/_partials/form-fields.tpl" field=$hooks dynamicField=false}
+    {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$hooks dynamicField=false}
 {/if}
 
 {if isset($widget_type) && $widget_type}
-    {include file="module:paypal/views/templates/admin/_partials/form-fields.tpl"
+    {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl"
       field=[
           'label' => 'Widget code',
           'type' => 'widget-code',
@@ -55,11 +55,11 @@
   </div>
 
     {if isset($color) && $color}
-        {include file="module:paypal/views/templates/admin/_partials/form-fields.tpl" field=$color dynamicField=false}
+        {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$color dynamicField=false}
     {/if}
 
     {if isset($shape) && $shape}
-        {include file="module:paypal/views/templates/admin/_partials/form-fields.tpl" field=$shape dynamicField=false}
+        {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$shape dynamicField=false}
     {/if}
 
     {if isset($height) && isset($width) && $height && $width}
@@ -107,7 +107,7 @@
     {/if}
 
     {if isset($label) && $label}
-        {include file="module:paypal/views/templates/admin/_partials/form-fields.tpl" field=$label dynamicField=false}
+        {include file=$moduleFullDir|cat:"/views/templates/admin/_partials/form-fields.tpl" field=$label dynamicField=false}
     {/if}
 
 </div>

--- a/views/templates/admin/_partials/statusBlock.tpl
+++ b/views/templates/admin/_partials/statusBlock.tpl
@@ -37,7 +37,7 @@
     <ul class="list-unstyled mb-0">
       <li class="d-flex mb-1">
         {include
-          file="module:paypal/views/templates/admin/_partials/icon-status.tpl"
+          file=$moduleFullDir|cat:"/views/templates/admin/_partials/icon-status.tpl"
           isSuccess=$vars.sslActivated|default:false
         }
         {if $vars.sslActivated|default:false}
@@ -50,7 +50,7 @@
       {if $vars.tlsVersion|default:false}
         <li class="d-flex mb-1">
           {include
-            file="module:paypal/views/templates/admin/_partials/icon-status.tpl"
+            file=$moduleFullDir|cat:"/views/templates/admin/_partials/icon-status.tpl"
             isSuccess=($vars.tlsVersion|default:false && $vars.tlsVersion['status'])
           }
           {if $vars.tlsVersion|default:false && $vars.tlsVersion['status']}
@@ -65,7 +65,7 @@
       {if $vars.showWebhookState|default:false}
         <li class="d-flex">
           {include
-            file="module:paypal/views/templates/admin/_partials/icon-status.tpl"
+            file=$moduleFullDir|cat:"/views/templates/admin/_partials/icon-status.tpl"
             isSuccess=$vars.webhookState|default:false
           }
           {if isset($vars.webhookStateMsg)}{$vars.webhookStateMsg nofilter}{/if}

--- a/views/templates/admin/_partials/welcome-board.tpl
+++ b/views/templates/admin/_partials/welcome-board.tpl
@@ -37,14 +37,14 @@
               <ul class="list-unstyled mb-0">
                 <li class="d-flex align-items-center mb-1">
                     {include
-                    file="module:paypal/views/templates/admin/_partials/icon-status.tpl"
+                    file=$moduleFullDir|cat:"/views/templates/admin/_partials/icon-status.tpl"
                     isSuccess=(false == $isSandbox|default:false)
                     }
                     {l s='Mode production enabled' mod='paypal'}
                 </li>
                 <li class="d-flex align-items-center">
                     {include
-                    file="module:paypal/views/templates/admin/_partials/icon-status.tpl"
+                    file=$moduleFullDir|cat:"/views/templates/admin/_partials/icon-status.tpl"
                     isSuccess=$isConfigured|default:false
                     }
                     {l s='Account connected' mod='paypal'}

--- a/views/templates/admin/admin.tpl
+++ b/views/templates/admin/admin.tpl
@@ -25,20 +25,20 @@
  *}
 {* Dashboard *}
 {include
-  file="module:paypal/views/templates/admin/_partials/dashboard.tpl"
+  file=$moduleFullDir|cat:"/views/templates/admin/_partials/dashboard.tpl"
   form=$trackingForm
 }
 
 {if $isShowModalConfiguration|default:false}
   {include
-    file="module:paypal/views/templates/admin/_partials/modal-configuration.tpl"
+    file=$moduleFullDir|cat:"/views/templates/admin/_partials/modal-configuration.tpl"
   }
 {else}
 
   {* Account section *}
     {if isset($accountForm)}
         {include
-          file="module:paypal/views/templates/admin/_partials/section.tpl"
+          file=$moduleFullDir|cat:"/views/templates/admin/_partials/section.tpl"
           form=$accountForm
         }
     {/if}
@@ -46,7 +46,7 @@
   {* Tracking section *}
   {if isset($trackingForm)}
       {include
-      file="module:paypal/views/templates/admin/_partials/section.tpl"
+      file=$moduleFullDir|cat:"/views/templates/admin/_partials/section.tpl"
       form=$trackingForm
       }
   {/if}
@@ -54,7 +54,7 @@
   {* Checkout section *}
   {if isset($checkoutForm)}
       {include
-        file="module:paypal/views/templates/admin/_partials/section.tpl"
+        file=$moduleFullDir|cat:"/views/templates/admin/_partials/section.tpl"
         form=$checkoutForm
       }
   {/if}
@@ -63,7 +63,7 @@
   {* Installment section *}
   {if isset($formInstallment)}
       {include
-        file="module:paypal/views/templates/admin/_partials/section.tpl"
+        file=$moduleFullDir|cat:"/views/templates/admin/_partials/section.tpl"
         form=$formInstallment
         sectionColFormClasses=' '
         sectionColInfoClasses=' '
@@ -73,7 +73,7 @@
     {* Shortcut section *}
   {if isset($shortcutConfigurationForm)}
       {include
-      file="module:paypal/views/templates/admin/_partials/section.tpl"
+      file=$moduleFullDir|cat:"/views/templates/admin/_partials/section.tpl"
       form=$shortcutConfigurationForm
       }
   {/if}
@@ -82,7 +82,7 @@
   {* Order status section *}
   {if isset($orderStatusForm)}
       {include
-      file="module:paypal/views/templates/admin/_partials/section.tpl"
+      file=$moduleFullDir|cat:"/views/templates/admin/_partials/section.tpl"
       form=$orderStatusForm
       }
   {/if}
@@ -90,7 +90,7 @@
   {* White list section *}
   {if isset($whiteListForm)}
       {include
-      file="module:paypal/views/templates/admin/_partials/section.tpl"
+      file=$moduleFullDir|cat:"/views/templates/admin/_partials/section.tpl"
       form=$whiteListForm
       }
   {/if}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Paypal PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Fix blank pages error for configuration with PrestaShop 1.7.5-. <br />Fix 500 error on configuration for countries not available for BNPL (differents of 'fr', 'de', 'gb', 'us', 'au', 'it', 'es')
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | #217 
| How to test?  | Test in PrestaShop 1.7.5- without the fix and blank page is displayed.<br />For BNPL, when you choose a default country different that mentionned above 500 error will be displayed.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
