### PR TITLE
refs #41062 modal for initial configuration is not opened on Firefox

### DIFF
--- a/202/_dev/js/admin.js
+++ b/202/_dev/js/admin.js
@@ -29,10 +29,8 @@ import Steps from './admin/steps';
 import Form from './admin/form';
 import Section from './admin/section';
 
-$(() => {
-  $(window).on('load', () => {
-    $('#modal-configuration').modal('show');
-  })
+window.addEventListener('load', () => {
+  $('#modal-configuration').modal('show');
 
   const steps = new Steps('#modal-configuration-steps');
   steps.init();
@@ -56,7 +54,5 @@ $(() => {
       ))
     );
   }
-
 });
-
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Paypal PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Modal for initial configuration is not opened on Firefox
| Type?         | bug fix / improvement / new feature / refacto / critical
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
