### PR TITLE
refs #41036 onboarding process in firefox

### DIFF
--- a/views/templates/admin/_partials/forms/pp_account_form.tpl
+++ b/views/templates/admin/_partials/forms/pp_account_form.tpl
@@ -224,9 +224,6 @@
     }
 
     window.addEventListener('load', function() {
-      var script = document.createElement('script');
-      script.src = 'https://www.paypal.com/webapps/merchantboarding/js/lib/lightbox/partner.js';
-      document.body.appendChild(script);
 
       var event = new CustomEvent(
         '{if $isShowCredentials}updateCredentials{else}updateButtonSection{/if}',
@@ -246,6 +243,7 @@
 
 
   </script>
+  <script src="https://www.paypal.com/webapps/merchantboarding/js/lib/lightbox/partner.js"></script>
 {/block}
 
 {block name='form_footer_buttons'}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Paypal PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Onboarding process doesn't work in Firefox
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | Try to configure the credentials section in Firefox. After consenting on the PayPal side, the module stays unconfigured

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
