### PR TITLE
refs #38919 orders status "no action"

### DIFF
--- a/202/docker/run_for_unittest.sh
+++ b/202/docker/run_for_unittest.sh
@@ -10,6 +10,7 @@ php /var/www/html/bin/console prestashop:module install paypal -e prod
 mysql -h localhost -u root prestashop -e "
 TRUNCATE ps_paypal_webhook;
 TRUNCATE ps_paypal_order;
+UPDATE ps_configuration SET value = '0' WHERE name = 'PAYPAL_CUSTOMIZE_ORDER_STATUS';
 "
 
 cd /var/www/html/modules/paypal/

--- a/classes/Webhook/WebhookEventHandler.php
+++ b/classes/Webhook/WebhookEventHandler.php
@@ -378,7 +378,9 @@ class WebhookEventHandler
             }
         }
 
-        return $this->getStatusMapping()->getPsOrderStatusByEventType($event->getEventType());
+        $idStatus = $this->getStatusMapping()->getPsOrderStatusByEventType($event->getEventType());
+
+        return $idStatus < 1 ? 0 : $idStatus;
     }
 
     protected function getPaymentTotal(WebhookEvent $event)

--- a/services/StatusMapping.php
+++ b/services/StatusMapping.php
@@ -102,6 +102,8 @@ class StatusMapping
             } else {
                 $idStatus = (int) Configuration::get('PAYPAL_OS_REFUNDED');
             }
+        } else {
+            $idStatus = (int) Configuration::get('PS_OS_REFUND');
         }
 
         if ($idStatus) {
@@ -142,6 +144,8 @@ class StatusMapping
                     $idStatus = (int) Configuration::get('PAYPAL_OS_CAPTURE_CANCELED');
                 }
             }
+        } else {
+            $idStatus = (int) Configuration::get('PS_OS_CANCELED');
         }
 
         if ($idStatus) {

--- a/services/StatusMapping.php
+++ b/services/StatusMapping.php
@@ -107,8 +107,8 @@ class StatusMapping
         if ($idStatus) {
             return $idStatus;
         }
-
-        return (int) Configuration::get('PS_OS_REFUND');
+        //no action
+        return -1;
     }
 
     public function getFailedStatus()
@@ -147,8 +147,8 @@ class StatusMapping
         if ($idStatus) {
             return $idStatus;
         }
-
-        return (int) Configuration::get('PS_OS_CANCELED');
+        //no action
+        return -1;
     }
 
     public function getWaitValidationStatus()


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Paypal PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Custom status "no action" for refund/cancel action
| Type?         | new feature
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #250 .
| How to test?  | Do nothing if "no action" is chosen for the refund/cancel action (no action sent to PayPal's API).

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
