### PR TITLE
refs #41462 - Fix SEPA, SOFORTand GIROPAY

### DIFF
--- a/classes/SEPA/SepaButton.php
+++ b/classes/SEPA/SepaButton.php
@@ -72,7 +72,7 @@ class SepaButton
     protected function getJSvars()
     {
         return [
-            $vars[PaypalConfigurations::MOVE_BUTTON_AT_END] = (int) Configuration::get(PaypalConfigurations::MOVE_BUTTON_AT_END),
+            PaypalConfigurations::MOVE_BUTTON_AT_END => (int) Configuration::get(PaypalConfigurations::MOVE_BUTTON_AT_END),
         ];
     }
 


### PR DESCRIPTION
If BNPL / ACDC is not activated not working.

<!-----------------------------------------------------------------------------
Thank you for contributing to the Paypal PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | SEPA, GIROPAY and SOFORT are not correctly working if BNPL / ACDC are disabled
| Type?         | bug fix 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #212
| How to test?  | Test SEPA alone without BNPL and ACDC enabled. The button is correctly generated without errors.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
