### PR TITLE
refs #41631 - Improve errors message

### DIFF
--- a/202/_dev/js/admin/form.js
+++ b/202/_dev/js/admin/form.js
@@ -320,10 +320,22 @@ class Form {
             document.querySelector('[name="paypal_secret_live"]').value = response.secret;
             document.querySelector('[name="merchant_id_live"]').value = response.merchantId;
           }
+        } else {
+          this.errorMessage(response);
         }
 
         this.updateButtonSection();
       });
+  }
+
+  errorMessage(response) {
+    let messageSection = '#paypal_error_ajax';
+    let prependTo = '[onboarding-button-section]';
+    if (!$(messageSection).length || $(messageSection).length <= 0) {
+      const htmlDiv = '<div id="paypal_error_ajax" class="alert alert-danger"></div>';
+      $(prependTo).append(htmlDiv);
+    }
+    $(messageSection).html(response.message);
   }
 
   isSandbox() {

--- a/controllers/admin/AdminPaypalConfigurationController.php
+++ b/controllers/admin/AdminPaypalConfigurationController.php
@@ -165,18 +165,18 @@ class AdminPaypalConfigurationController extends \ModuleAdminController
         $result = $paypalOnboarding->execute();
 
         $locale = \Context::getContext()->language->locale;
-        $errorMessage = $this->module->l(
-            'An error occured while trying to link your PayPal\'s account',
-            'AdminPaypalConfigurationController',
-            $locale
-        );
-        $errorMessage .= '<br />' . $this->module->l('More details: ', 'AdminPaypalConfigurationController', $locale) . '<br />';
+        $errorMessages = [
+            $this->module->l(
+                'An error occured while trying to link your PayPal\'s account',
+                'AdminPaypalConfigurationController',
+                $locale
+            ),
+        ];
+        $errorMessages[] = $this->module->l('More details: ', 'AdminPaypalConfigurationController', $locale);
+
         if ($result->isSuccess() == false) {
-            $response->setData([
-                'success' => false,
-                'message' => $errorMessage . $result->getError()->getMessage(),
-            ])->send();
-            exit;
+            $errorMessages[] = $result->getError()->getMessage();
+            $this->errorTemplate($response, $errorMessages);
         }
 
         $authToken = $result->getAuthToken();
@@ -186,11 +186,8 @@ class AdminPaypalConfigurationController extends \ModuleAdminController
         $result = $paypalGetCredentials->execute();
 
         if ($result->isSuccess() == false) {
-            $response->setData([
-                'success' => false,
-                'message' => $result->getError()->getMessage(),
-            ])->send();
-            exit;
+            $errorMessage[] = $result->getError()->getMessage();
+            $this->errorTemplate($response, $errorMessages);
         }
 
         $params = [
@@ -207,6 +204,26 @@ class AdminPaypalConfigurationController extends \ModuleAdminController
             'secret' => $result->getSecret(),
             'merchantId' => $result->getMerchantId(),
             'isSandbox' => $isSandbox,
+        ])->send();
+        exit;
+    }
+
+    /**
+     * Send Error message
+     *
+     * @param JsonResponse $response
+     * @param mixed $messages
+     */
+    private function errorTemplate($response, $messages)
+    {
+        $template = $this->context->smarty->createTemplate(
+            $this->getTemplatePath() . '_partials/alert_ajax.tpl'
+        );
+        $template->assign('messages', $messages);
+
+        $response->setData([
+            'success' => false,
+            'message' => $template->fetch(),
         ])->send();
         exit;
     }

--- a/controllers/admin/AdminPaypalConfigurationController.php
+++ b/controllers/admin/AdminPaypalConfigurationController.php
@@ -164,8 +164,18 @@ class AdminPaypalConfigurationController extends \ModuleAdminController
         $paypalOnboarding = new PaypalGetAuthToken($authCode, $sharedId, $sellerNonce, $isSandbox);
         $result = $paypalOnboarding->execute();
 
+        $locale = \Context::getContext()->language->locale;
+        $errorMessage = $this->module->l(
+            'An error occured while trying to link your PayPal\'s account',
+            'AdminPaypalConfigurationController',
+            $locale
+        );
+        $errorMessage .= '<br />' . $this->module->l('More details: ', 'AdminPaypalConfigurationController', $locale) . '<br />';
         if ($result->isSuccess() == false) {
-            $response->setData(['success' => false, 'message' => $result->getError()->getMessage()])->send();
+            $response->setData([
+                'success' => false,
+                'message' => $errorMessage . $result->getError()->getMessage()
+            ])->send();
             exit;
         }
 
@@ -176,7 +186,10 @@ class AdminPaypalConfigurationController extends \ModuleAdminController
         $result = $paypalGetCredentials->execute();
 
         if ($result->isSuccess() == false) {
-            $response->setData(['success' => false, 'messeage' => $result->getError()->getMessage()])->send();
+            $response->setData([
+                'success' => false,
+                'message' => $result->getError()->getMessage()]
+            )->send();
             exit;
         }
 

--- a/controllers/admin/AdminPaypalConfigurationController.php
+++ b/controllers/admin/AdminPaypalConfigurationController.php
@@ -174,7 +174,7 @@ class AdminPaypalConfigurationController extends \ModuleAdminController
         if ($result->isSuccess() == false) {
             $response->setData([
                 'success' => false,
-                'message' => $errorMessage . $result->getError()->getMessage()
+                'message' => $errorMessage . $result->getError()->getMessage(),
             ])->send();
             exit;
         }
@@ -188,8 +188,8 @@ class AdminPaypalConfigurationController extends \ModuleAdminController
         if ($result->isSuccess() == false) {
             $response->setData([
                 'success' => false,
-                'message' => $result->getError()->getMessage()]
-            )->send();
+                'message' => $result->getError()->getMessage(),
+            ])->send();
             exit;
         }
 

--- a/translations/es.php
+++ b/translations/es.php
@@ -214,6 +214,8 @@ $_MODULE['<{paypal}prestashop>adminpaypalcontroller_2c4493f4907a8c500557d79dd978
 $_MODULE['<{paypal}prestashop>adminpaypalcontroller_d8e95938c82a618f755c13b35d4277c4'] = 'Estás usando una versión anterior de cURL. Actualiza tu extensión cURL a la versión 7.34.0 o superior.';
 $_MODULE['<{paypal}prestashop>adminpaypalcontroller_38dc1dc4db247b4c01b26636e6bf9666'] = 'La versión de TLS no es compatible';
 $_MODULE['<{paypal}prestashop>adminpaypalcontroller_b4a34d3f58b039e7685c2e39b5413757'] = 'Actualización realizada correctamente.';
+$_MODULE['<{paypal}prestashop>adminpaypalconfigurationcontroller_5a4ee3dd035d8deb0d2ac20207e6fae8'] = 'Se ha producido un error al vincular su cuenta PayPal';
+$_MODULE['<{paypal}prestashop>adminpaypalconfigurationcontroller_46d27bd77ba9412d8515682b635cd01a'] = 'Para más información:';
 $_MODULE['<{paypal}prestashop>createprofileexperiencerequest_51a9f5fc2e4d9b1c8aa4a60a7c725243'] = 'Se ha producido un error al crear tu experiencia web. Comprueba tus credenciales.';
 $_MODULE['<{paypal}prestashop>methodppp_51a9f5fc2e4d9b1c8aa4a60a7c725243'] = 'Se ha producido un error al crear tu experiencia web. Comprueba tus credenciales.';
 $_MODULE['<{paypal}prestashop>adminprocessloggercontroller_d3b206d196cd6be3a2764c1fb90b200f'] = 'Eliminar selección';

--- a/translations/fr.php
+++ b/translations/fr.php
@@ -217,6 +217,8 @@ $_MODULE['<{paypal}prestashop>adminpaypalcontroller_2c4493f4907a8c500557d79dd978
 $_MODULE['<{paypal}prestashop>adminpaypalcontroller_d8e95938c82a618f755c13b35d4277c4'] = 'Vous utilisez une ancienne version de cURL. Mettez à jour votre extension cURL vers la version 7.34.0 ou supérieure.';
 $_MODULE['<{paypal}prestashop>adminpaypalcontroller_38dc1dc4db247b4c01b26636e6bf9666'] = 'La version de TLS n\'est pas compatible.';
 $_MODULE['<{paypal}prestashop>adminpaypalcontroller_b4a34d3f58b039e7685c2e39b5413757'] = 'Mise à jour réussie.';
+$_MODULE['<{paypal}prestashop>adminpaypalconfigurationcontroller_5a4ee3dd035d8deb0d2ac20207e6fae8'] = 'Une erreur s\'est produite lors de la liaison de votre compte PayPal';
+$_MODULE['<{paypal}prestashop>adminpaypalconfigurationcontroller_46d27bd77ba9412d8515682b635cd01a'] = 'Plus de détails :';
 $_MODULE['<{paypal}prestashop>createprofileexperiencerequest_51a9f5fc2e4d9b1c8aa4a60a7c725243'] = 'Une erreur est survenue lors de la création de votre expérience web. Vérifiez vos identifiants.';
 $_MODULE['<{paypal}prestashop>methodppp_51a9f5fc2e4d9b1c8aa4a60a7c725243'] = 'Une erreur est survenue lors de la création de votre expérience web. Vérifiez vos identifiants.';
 $_MODULE['<{paypal}prestashop>adminprocessloggercontroller_d3b206d196cd6be3a2764c1fb90b200f'] = 'Supprimer la sélection';

--- a/translations/it.php
+++ b/translations/it.php
@@ -213,6 +213,8 @@ $_MODULE['<{paypal}prestashop>adminpaypalcontroller_2c4493f4907a8c500557d79dd978
 $_MODULE['<{paypal}prestashop>adminpaypalcontroller_d8e95938c82a618f755c13b35d4277c4'] = 'Stai utilizzando una vecchia versione di cURL. Aggiorna la tua estensione cURL alla versione 7.34.0 o successiva.';
 $_MODULE['<{paypal}prestashop>adminpaypalcontroller_38dc1dc4db247b4c01b26636e6bf9666'] = 'La versione TLS non è compatibile';
 $_MODULE['<{paypal}prestashop>adminpaypalcontroller_b4a34d3f58b039e7685c2e39b5413757'] = 'Aggiornamento riuscito.';
+$_MODULE['<{paypal}prestashop>adminpaypalconfigurationcontroller_5a4ee3dd035d8deb0d2ac20207e6fae8'] = 'Si è verificato un errore durante il collegamento del conto PayPal';
+$_MODULE['<{paypal}prestashop>adminpaypalconfigurationcontroller_46d27bd77ba9412d8515682b635cd01a'] = 'Per maggiori dettagli:';
 $_MODULE['<{paypal}prestashop>createprofileexperiencerequest_51a9f5fc2e4d9b1c8aa4a60a7c725243'] = 'Errore durante la creazione della tua esperienza web. Controlla le credenziali.';
 $_MODULE['<{paypal}prestashop>methodppp_51a9f5fc2e4d9b1c8aa4a60a7c725243'] = 'Errore durante la creazione della tua esperienza web. Controlla le credenziali.';
 $_MODULE['<{paypal}prestashop>adminprocessloggercontroller_d3b206d196cd6be3a2764c1fb90b200f'] = 'Elimina selezione';

--- a/views/templates/admin/_partials/alert_ajax.tpl
+++ b/views/templates/admin/_partials/alert_ajax.tpl
@@ -23,7 +23,6 @@
  *  @copyright PayPal
  *
  *}
-{* {json_encode($messages)} *}
 {foreach from=$messages item=message}
     {$message|escape:'htmlall':'UTF-8'}<br />
 {/foreach}

--- a/views/templates/admin/_partials/alert_ajax.tpl
+++ b/views/templates/admin/_partials/alert_ajax.tpl
@@ -1,0 +1,29 @@
+{**
+ * 2007-2023 PayPal
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ *  versions in the future. If you wish to customize PrestaShop for your
+ *  needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author 2007-2023 PayPal
+ *  @author 202 ecommerce <tech@202-ecommerce.com>
+ *  @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ *  @copyright PayPal
+ *
+ *}
+{* {json_encode($messages)} *}
+{foreach from=$messages item=message}
+    {$message|escape:'htmlall':'UTF-8'}<br />
+{/foreach}


### PR DESCRIPTION
Add error display while generating credentials

<!-----------------------------------------------------------------------------
Thank you for contributing to the Paypal PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Return errors on login when the generation of credentials to link the Shop to PayPal fails.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | When an error is returned on the credentials generation you will get this display :<br />![image](https://github.com/202ecommerce/paypal/assets/98040531/327220c4-9c06-4c75-928f-0d9e51af15c1)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

