### PR TITLE
refs #41589 - Fix webhook order message

### DIFF
--- a/202/build.xml
+++ b/202/build.xml
@@ -30,7 +30,7 @@
     <property name="src-dir" value="${basedir}" />
     <property name="TARGETNAME" value="paypal" />
     <property name="TARGETBRANCH" value="${env.GIT_BRANCH}" />
-    <property name="TARGETVERSION" value="6.0.2" />
+    <property name="TARGETVERSION" value="6.0.3" />
     <property name="PHPVERSION" value="5.6" />
     <property name="PSVERSION" value="1.7.5.2" />
 

--- a/services/WebhookService.php
+++ b/services/WebhookService.php
@@ -80,6 +80,7 @@ class WebhookService
     {
         $webhooks = [];
         $query = (new DbQuery())
+            ->select('id_paypal_webhook')
             ->from(\PaypalWebhook::$definition['table'])
             ->where('id_paypal_order = ' . (int) $paypalOrder->id)
             ->where('id_webhook IS NULL OR id_webhook = ""');
@@ -108,9 +109,10 @@ class WebhookService
 
         foreach ($result as $row) {
             try {
-                $webhook = new \PaypalWebhook();
-                $webhook->hydrate($row);
-                $webhooks[] = $webhook;
+                $webhook = new \PaypalWebhook($row['id_paypal_webhook']);
+                if (Validate::isLoadedObject($webhook) === true) {
+                    $webhooks[] = $webhook;
+                }
             } catch (Throwable $e) {
             } catch (Exception $e) {
             }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Paypal PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | After update in some cases on order one message is displayed : <br />Event notification has not been received yet. Please check if your website has a correct SSL certificate (https) or htaccess are not enabled.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #249, #268
| How to test?  | After update to 6.0.3 with this fix, these message will not be displayed anymore.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
