### PR TITLE
refs #41707 - Fix quick order preview

### DIFF
--- a/vendor/ppbtlib/src/Extensions/ProcessLogger/ProcessLoggerExtension.php
+++ b/vendor/ppbtlib/src/Extensions/ProcessLogger/ProcessLoggerExtension.php
@@ -128,6 +128,7 @@ class ProcessLoggerExtension extends AbstractModuleExtension
         }
 
         $collectionLogs = new \PrestaShopCollection($class_logger);
+        $collectionLogs->where('id_order', '=', $order->id);
         $collectionLogs
             ->orderBy('date_add', 'desc');
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Paypal PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The ID Transaction was incorrect on any orders differents than the the last done.<br />ID Transaction of last order was always displayed.
| Type?         | bug fix
| BC breaks?    | yes
| Deprecations? | yes
| Fixed ticket? | #257.
| How to test?  | After this fix, only selected order ID transaction will be displayed.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
