### PR TITLE
Hotfixes/41672 parse transaction date

### DIFF
--- a/classes/API/Request/PaypalCaptureAuthorizeRequest.php
+++ b/classes/API/Request/PaypalCaptureAuthorizeRequest.php
@@ -97,6 +97,10 @@ class PaypalCaptureAuthorizeRequest extends RequestAbstract
     {
         $date = \DateTime::createFromFormat(\DateTime::ATOM, $exec->result->create_time);
 
+        if (!$date) {
+            $date = new \DateTime();
+        }
+
         return $date->format('Y-m-d H:i:s');
     }
 }

--- a/classes/API/Request/PaypalOrderAuthorizeRequest.php
+++ b/classes/API/Request/PaypalOrderAuthorizeRequest.php
@@ -135,6 +135,10 @@ class PaypalOrderAuthorizeRequest extends RequestAbstract
         $transaction = $payemnts->authorizations[0];
         $date = \DateTime::createFromFormat(\DateTime::ATOM, $transaction->create_time);
 
+        if (!$date) {
+            $date = new \DateTime();
+        }
+
         return $date;
     }
 

--- a/classes/API/Request/PaypalOrderCaptureRequest.php
+++ b/classes/API/Request/PaypalOrderCaptureRequest.php
@@ -134,6 +134,10 @@ class PaypalOrderCaptureRequest extends RequestAbstract
         $transaction = $payemnts->captures[0];
         $date = \DateTime::createFromFormat(\DateTime::ATOM, $transaction->create_time);
 
+        if (!$date) {
+            $date = new \DateTime();
+        }
+
         return $date;
     }
 

--- a/classes/API/Request/PaypalOrderGetRequest.php
+++ b/classes/API/Request/PaypalOrderGetRequest.php
@@ -284,6 +284,10 @@ class PaypalOrderGetRequest extends RequestAbstract
         $transaction = $payments->captures[0];
         $date = \DateTime::createFromFormat(\DateTime::ATOM, $transaction->create_time);
 
+        if (!$date) {
+            $date = new \DateTime();
+        }
+
         return $date;
     }
 

--- a/classes/API/Request/PaypalOrderRefundRequest.php
+++ b/classes/API/Request/PaypalOrderRefundRequest.php
@@ -110,6 +110,10 @@ class PaypalOrderRefundRequest extends RequestAbstract
     {
         $date = \DateTime::createFromFormat(\DateTime::ATOM, $exec->result->create_time);
 
+        if (!$date instanceof \DateTime) {
+            $date = new \DateTime();
+        }
+
         return $date->format('Y-m-d H:i:s');
     }
 

--- a/classes/API/Request/V_1/PaypalOrderCaptureRequest.php
+++ b/classes/API/Request/V_1/PaypalOrderCaptureRequest.php
@@ -177,6 +177,10 @@ class PaypalOrderCaptureRequest extends RequestAbstractMB
     {
         $date = \DateTime::createFromFormat(\DateTime::ISO8601, $payment->update_time);
 
+        if (!$date) {
+            $date = new \DateTime();
+        }
+
         return $date;
     }
 }

--- a/classes/API/Request/V_1/PaypalOrderRefundRequest.php
+++ b/classes/API/Request/V_1/PaypalOrderRefundRequest.php
@@ -101,6 +101,10 @@ class PaypalOrderRefundRequest extends RequestAbstractMB
     {
         $date = DateTime::createFromFormat(DateTime::ISO8601, $detailedRefund->update_time);
 
+        if (!$date) {
+            $date = new DateTime();
+        }
+
         return $date->format('Y-m-d TH:i:s');
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Paypal PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Returns a current date if parse transaction date is failled
| Type?         | bug fix
| BC breaks?    |  no
| Deprecations? |  no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | Pay the order by invoice. The error occurs during the order creation. Message: Argument 1 passed to PaypalAddonsclassesAPIResponseResponseOrderGet::setDateTransaction() must be an instance of DateTime, bool given, called in /modules/paypal/classes/API/Request/PaypalOrderGetRequest.php

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
