### PR TITLE
refs #41567 error while save PaypalWebhook object

### DIFF
--- a/classes/PaypalWebhook.php
+++ b/classes/PaypalWebhook.php
@@ -65,7 +65,7 @@ class PaypalWebhook extends ObjectModel
         'fields' => [
             'id_paypal_order' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId'],
             'id_webhook' => ['type' => self::TYPE_STRING, 'validate' => 'isCleanHtml', 'size' => 50],
-            'event_type' => ['type' => self::TYPE_STRING, 'validate' => 'isCleanHtml', 'size' => 20],
+            'event_type' => ['type' => self::TYPE_STRING, 'validate' => 'isCleanHtml', 'size' => 50],
             'data' => ['type' => self::TYPE_HTML, 'validate' => 'isCleanHtml'],
             'id_state' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId'],
             'date_add' => ['type' => self::TYPE_DATE, 'validate' => 'isDateFormat'],

--- a/classes/Webhook/WebhookEventHandler.php
+++ b/classes/Webhook/WebhookEventHandler.php
@@ -174,10 +174,10 @@ class WebhookEventHandler
             $paypalWebhook->save();
         } catch (Throwable $e) {
             $paypalWebhook->data = '';
-            $paypalOrder->save();
+            $paypalWebhook->save();
         } catch (Exception $e) {
             $paypalWebhook->data = '';
-            $paypalOrder->save();
+            $paypalWebhook->save();
         }
 
         if ($psOrderStatus == $this->getStatusMapping()->getAcceptedStatus()) {

--- a/upgrade/Upgrade-6.0.3.php
+++ b/upgrade/Upgrade-6.0.3.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * 2007-2023 PayPal
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ *  versions in the future. If you wish to customize PrestaShop for your
+ *  needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author 2007-2023 PayPal
+ *  @author 202 ecommerce <tech@202-ecommerce.com>
+ *  @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ *  @copyright PayPal
+ *
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * @param $module PayPal
+ *
+ * @return bool
+ */
+function upgrade_module_6_0_3($module)
+{
+    $installer = new \PaypalPPBTlib\Install\ModuleInstaller($module);
+    $installer->installObjectModels();
+
+    return true;
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Paypal PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Msg. "A request has been sent to PayPal." on order page in BO doesn't disappear after receiving the webhook
| Type?         | bug fix
| BC breaks?    |  no
| Deprecations? |  no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | 


![scrnli_01_08_2023_18-02-48](https://github.com/202ecommerce/paypal/assets/44570209/48c4d830-6f61-432f-8df3-e3be5f7a0555)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
