### PR TITLE
refs #41754 missing error detail in log message

### DIFF
--- a/classes/API/Request/PaypalAddTrackingInfoRequest.php
+++ b/classes/API/Request/PaypalAddTrackingInfoRequest.php
@@ -78,6 +78,8 @@ class PaypalAddTrackingInfoRequest extends RequestAbstract
 
             if (false == empty($resultDecoded['message'])) {
                 $error->setMessage($resultDecoded['message']);
+            } else {
+                $error->setMessage($e->getMessage());
             }
 
             $response->setSuccess(false)


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Paypal PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Log message doesn't contain the error detail
| Type?         | improvement
| BC breaks?    |  no
| Deprecations? |  no
| Fixed ticket? | Fixes #271.
| How to test?  | 


![Selection_591](https://github.com/202ecommerce/paypal/assets/44570209/b59e29bb-9d12-4fff-8d00-c69e65bdaf49)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
