### PR TITLE
refs #41821 - Fix credentials recuperation

### DIFF
--- a/202/_dev/js/admin/form.js
+++ b/202/_dev/js/admin/form.js
@@ -6,6 +6,7 @@ class Form {
     this.inputDynamicSelector = '.custom-control-input';
     this.inputInstallementColor = '[name="PAYPAL_INSTALLMENT_COLOR"]';
     this.controller = document.location.href;
+    this.generateCredentialsEventDone = false;
   }
 
   init() {
@@ -294,12 +295,16 @@ class Form {
   }
 
   generateCredentials(data) {
+    if (this.generateCredentialsEventDone === true) {
+      return false;
+    }
     const url = new URL(this.controller);
     url.searchParams.append('ajax', 1);
     url.searchParams.append('action', 'generateCredentials');
     url.searchParams.append('authCode', data.authCode);
     url.searchParams.append('sharedId', data.sharedId);
     url.searchParams.append('isSandbox', this.isSandbox() ? 1 : 0);
+    this.generateCredentialsEventDone = true;
 
     fetch(url.toString(), {
       method: 'GET',
@@ -325,6 +330,7 @@ class Form {
         }
 
         this.updateButtonSection();
+        this.generateCredentialsEventDone = false;
       });
   }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Paypal PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Fix sending several times the request when staying on the login admin page with login / logout several times.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | None.
| How to test?  | Login and logout on the account configuration page. Keep the DevTools opened to see AJAX request. Before this fix, you could have more than one request to generate credentials sent and an error message displayed.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
