### PR TITLE
refs #41689 - Fix Mexican and Bresilian issue

### DIFF
--- a/views/templates/admin/_partials/forms/pp_checkout_form.tpl
+++ b/views/templates/admin/_partials/forms/pp_checkout_form.tpl
@@ -28,7 +28,7 @@
 {block name='form_content'}
 
     {foreach from=$form.fields item=field}
-        {if $field.name|in_array:['PAYPAL_API_INTENT', 'PAYPAL_EXPRESS_CHECKOUT_IN_CONTEXT']}
+        {if $field.name|in_array:['PAYPAL_API_INTENT', 'PAYPAL_EXPRESS_CHECKOUT_IN_CONTEXT', 'PAYPAL_MB_EC_ENABLED']}
             {include file="../form-fields.tpl" field=$field }
         {/if}
     {/foreach}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Paypal PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Bresilian and Mexican configurations have one option that was not correctly restored when migrating to 6.0 version. After this fix, the option "Accept PayPal's payments" is correctly displayed on the configuration.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | None.
| How to test?  | Set default country to Mexico or Brazil. Now the switch "Accept PayPal payments" is correctly displayed on the top of the section checkout in the configuration.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
