### PR TITLE
refs #42000 - Display button paypal if alone

### DIFF
--- a/202/_dev/js/tools.js
+++ b/202/_dev/js/tools.js
@@ -73,6 +73,7 @@ export const Tools = {
     Tools.disable(disabledElement);
 
     checkBox.addEventListener('click', function() {
+      Tools.hideElementTillChecked();
       Tools.showElementsIfChecked();
       if (checkBox.checked) {
         Tools.enable(disabledElement);
@@ -82,7 +83,6 @@ export const Tools = {
     });
 
     $('.payment-option').click(function() {
-      Tools.showElementsIfChecked();
       if (checkBox.checked) {
         Tools.enable(disabledElement);
       } else {
@@ -137,20 +137,8 @@ export const Tools = {
       return;
     }
 
-    options.addEventListener('input', function(event) {
-      let isHide = false;
-      window.paypalToolsHiddenElemenList[hideElementSelector].forEach(function(elem) {
-        if (elem.checked) {
-          isHide = true;
-        }
-      });
-
-      if (isHide) {
-        hideElement.style.visibility = 'hidden';
-      } else {
-        hideElement.style.visibility = 'initial';
-      }
-    })
+    Tools.hideElementTillChecked();
+    options.addEventListener('input', Tools.hideElementTillChecked);
   },
 
   showElementIfPaymentOptionChecked(checkElementSelector, showElementSelector) {
@@ -181,20 +169,8 @@ export const Tools = {
       return;
     }
 
-    options.addEventListener('input', function(event) {
-      let isShow = false;
-      window.paypalToolsShowElemenList[showElementSelector].forEach(function(elem) {
-        if (elem.checked) {
-          isShow = true;
-        }
-      });
-
-      if (isShow) {
-        showElement.style.display = 'block';
-      } else {
-        showElement.style.display = 'none';
-      }
-    });
+    Tools.showElementsIfChecked();
+    options.addEventListener('input', Tools.showElementsIfChecked);
   },
 
   showElementsIfChecked() {
@@ -211,6 +187,24 @@ export const Tools = {
         showElement.style.display = 'block';
       } else {
         showElement.style.display = 'none';
+      }
+    });
+  },
+
+  hideElementTillChecked() {
+    Object.keys(window.paypalToolsHiddenElemenList).forEach(function(hideElementSelector) {
+      let isHide = false;
+      const hideElement = document.querySelector(hideElementSelector);
+      window.paypalToolsHiddenElemenList[hideElementSelector].forEach(function(elem) {
+        if (elem.checked) {
+          isHide = true;
+        }
+      });
+
+      if (isHide) {
+        hideElement.style.visibility = 'hidden';
+      } else {
+        hideElement.style.visibility = 'initial';
       }
     });
   },

--- a/202/_dev/js/tools.js
+++ b/202/_dev/js/tools.js
@@ -73,6 +73,7 @@ export const Tools = {
     Tools.disable(disabledElement);
 
     checkBox.addEventListener('click', function() {
+      Tools.showElementsIfChecked();
       if (checkBox.checked) {
         Tools.enable(disabledElement);
       } else {
@@ -81,6 +82,7 @@ export const Tools = {
     });
 
     $('.payment-option').click(function() {
+      Tools.showElementsIfChecked();
       if (checkBox.checked) {
         Tools.enable(disabledElement);
       } else {
@@ -186,6 +188,25 @@ export const Tools = {
           isShow = true;
         }
       });
+
+      if (isShow) {
+        showElement.style.display = 'block';
+      } else {
+        showElement.style.display = 'none';
+      }
+    });
+  },
+
+  showElementsIfChecked() {
+    Object.keys(window.paypalToolsShowElemenList).forEach(function(showElementSelector) {
+      console.log(showElementSelector);
+      let isShow = false;
+      window.paypalToolsShowElemenList[showElementSelector].forEach(function(elem) {
+        if (elem.checked) {
+          isShow = true;
+        }
+      });
+      const showElement = document.querySelector(showElementSelector);
 
       if (isShow) {
         showElement.style.display = 'block';

--- a/202/_dev/js/tools.js
+++ b/202/_dev/js/tools.js
@@ -199,7 +199,6 @@ export const Tools = {
 
   showElementsIfChecked() {
     Object.keys(window.paypalToolsShowElemenList).forEach(function(showElementSelector) {
-      console.log(showElementSelector);
       let isShow = false;
       window.paypalToolsShowElemenList[showElementSelector].forEach(function(elem) {
         if (elem.checked) {

--- a/views/templates/shortcut/shortcut-payment-step.tpl
+++ b/views/templates/shortcut/shortcut-payment-step.tpl
@@ -71,10 +71,6 @@
                   document.querySelector('[paypal-ec-wrong-button-message]').style.display = 'block';
               }
           });
-
-          $("#conditions_to_approve\\[terms-and-conditions\\]").change(function(event) {
-              checkPaymentOptionPayPal();
-          });
       });
 
       if (typeof Shortcut != "undefined") {
@@ -93,7 +89,6 @@
             '[data-module-name="paypal"]',
             '[paypal-button-container]'
           );
-          checkPaymentOptionPayPal();
       } else {
           document.addEventListener('paypal-after-init-shortcut-button', function (event) {
               Shortcut.addMarkTo(
@@ -112,20 +107,6 @@
                 '[paypal-button-container]'
               );
           })
-          checkPaymentOptionPayPal();
-      }
-
-      function checkPaymentOptionPayPal() {
-          if(Shortcut.isMoveButtonAtEnd) {
-            $('#payment-confirmation').css('visibility', '');
-          }
-          let selectedOption = $('input[name=payment-option]:checked');
-          if (selectedOption.attr("data-module-name") == "paypal") {
-            $('[paypal-button-container]').css('display', 'block');
-            if(Shortcut.isMoveButtonAtEnd) {
-              $('#payment-confirmation').css('visibility', 'hidden');
-            }
-          }
       }
   </script>
 {/block}

--- a/views/templates/shortcut/shortcut-payment-step.tpl
+++ b/views/templates/shortcut/shortcut-payment-step.tpl
@@ -71,6 +71,10 @@
                   document.querySelector('[paypal-ec-wrong-button-message]').style.display = 'block';
               }
           });
+
+          $("#conditions_to_approve\\[terms-and-conditions\\]").change(function(event) {
+              checkPaymentOptionPayPal();
+          });
       });
 
       if (typeof Shortcut != "undefined") {
@@ -89,6 +93,7 @@
             '[data-module-name="paypal"]',
             '[paypal-button-container]'
           );
+          checkPaymentOptionPayPal();
       } else {
           document.addEventListener('paypal-after-init-shortcut-button', function (event) {
               Shortcut.addMarkTo(
@@ -107,6 +112,20 @@
                 '[paypal-button-container]'
               );
           })
+          checkPaymentOptionPayPal();
+      }
+
+      function checkPaymentOptionPayPal() {
+          if(Shortcut.isMoveButtonAtEnd) {
+            $('#payment-confirmation').css('visibility', '');
+          }
+          let selectedOption = $('input[name=payment-option]:checked');
+          if (selectedOption.attr("data-module-name") == "paypal") {
+            $('[paypal-button-container]').css('display', 'block');
+            if(Shortcut.isMoveButtonAtEnd) {
+              $('#payment-confirmation').css('visibility', 'hidden');
+            }
+          }
       }
   </script>
 {/block}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Paypal PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Display PayPal button if alone on the checkout. <br />Add a new event to catch if terms of conditions are approved and show / enable the button if alone.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | None.
| How to test?  | Place paypal alone in the payment methods. <br />Before this fix, even with accepting conditions button is hidden and disabled in classic theme.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
