### PR TITLE
Bugfix/41031 add custom id informations

### DIFF
--- a/202/_dev/js/shortcut.js
+++ b/202/_dev/js/shortcut.js
@@ -157,6 +157,7 @@ const Shortcut = {
       data['idProduct'] = this.idProduct;
       data['quantity'] = this.productQuantity;
       data['combination'] = this.combination.join('|');
+      data['sc'] = true;
     }
 
     if (this.isAddAddress) {
@@ -190,6 +191,7 @@ const Shortcut = {
       data['idProduct'] = this.idProduct;
       data['quantity'] = this.productQuantity;
       data['combination'] = this.combination.join('|');
+      data['sc'] = true;
     }
 
     fetch(url.toString(),

--- a/classes/AbstractMethodPaypal.php
+++ b/classes/AbstractMethodPaypal.php
@@ -384,10 +384,14 @@ abstract class AbstractMethodPaypal extends AbstractMethod
     public function getCustomFieldInformation(Cart $cart)
     {
         $module = \Module::getInstanceByName($this->name);
-        $return = $module->l('Cart ID: ', get_class($this)) . $cart->id . '.';
+        $return = (string) _PS_VERSION_ . '_' . (string) $module->version . '_' . \phpversion() . '_';
+        if (Tools::getValue('sc') !== false) {
+            $return .= '_ESC_';
+        }
+        $return .= $module->l('Cart ID: ', get_class($this)) . $cart->id . '_';
         $return .= $module->l('Shop name: ', get_class($this)) . \Configuration::get('PS_SHOP_NAME', null, $cart->id_shop);
 
-        return $return;
+        return \substr($return, 0, 137);
     }
 
     public function getBrandName()

--- a/classes/AbstractMethodPaypal.php
+++ b/classes/AbstractMethodPaypal.php
@@ -386,7 +386,7 @@ abstract class AbstractMethodPaypal extends AbstractMethod
         $module = \Module::getInstanceByName($this->name);
         $return = (string) _PS_VERSION_ . '_' . (string) $module->version . '_' . \phpversion() . '_';
         if (Tools::getValue('sc') !== false) {
-            $return .= '_ESC_';
+            $return .= 'ESC_';
         }
         $return .= $module->l('Cart ID: ', get_class($this)) . $cart->id . '_';
         $return .= $module->l('Shop name: ', get_class($this)) . \Configuration::get('PS_SHOP_NAME', null, $cart->id_shop);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Paypal PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description  | Add custom_id informations on create order request. Only for debug purpose and PayPal's support.<br />Add module version, prestashop version and php version.
| Type         | improvement
| BC breaks    | no
| Deprecations | no
| Fixed ticket | None.
| How to test  | Only for PayPal's support purpose. Request can be analysed to see that the custom_id sent is improved with elements mentionned above.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
