### PR TITLE
Fix the Webpack5 deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
         "webpack": "^5.75.0",
         "webpack-cli": "^5.0.1",
         "webpack-dev-server": "^4.11.1",
-        "webpack-fix-style-only-entries": "^0.6.1"
+        "webpack-remove-empty-scripts": "^1.0.4"
     },
     "dependencies": {
         "axios": "^0.21.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,13 +24,13 @@
  *
  */
 const path = require('path');
-const FixStyleOnlyEntriesPlugin = require('webpack-fix-style-only-entries');
+const RemoveEmptyScripts = require('webpack-remove-empty-scripts');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 
 const minimizers = [];
 const plugins = [
-  new FixStyleOnlyEntriesPlugin(),
+  new RemoveEmptyScripts(),
   new MiniCssExtractPlugin({
     filename: '[name].css',
   }),


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Paypal PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Fix the Webpack5 deprecation warning.
| Type?         | bug fix 
| BC breaks?    | no
| Deprecations? | yes
| Fixed ticket? | no
| How to test?  | `npm run build` => no deprecation warnings

Hello,

this project uses the outdated [webpack-fix-style-only-entries](https://www.npmjs.com/package/webpack-fix-style-only-entries) plugin that is incompatible with `Webpack 5`.

Using `npm run build` appear the deprecation warnings:
```
webpack-fix-style-only-entries:
(node:18462) [DEP_WEBPACK_CHUNK_ENTRY_MODULE] DeprecationWarning: Chunk.entryModule: Use new ChunkGraph API
(node:18462) [DEP_WEBPACK_MODULE_INDEX] DeprecationWarning: Module.index: Use new ModuleGraph API
(node:18462) [DEP_WEBPACK_DEPRECATION_ARRAY_TO_SET] DeprecationWarning: chunk.files was changed from Array to Set (using Array method 'filter' is deprecated)
```
The author of the [webpack-fix-style-only-entries](https://www.npmjs.com/package/webpack-fix-style-only-entries) plugin recommends using the [webpack-remove-empty-scripts](https://github.com/webdiscus/webpack-remove-empty-scripts) plugin for Webpack 5.

This PR just replaces the outdated plugin with the actual version.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
