### PR TITLE
refs #42567 pui is displayed even if option is disabled

### DIFF
--- a/classes/PUI/PuiFunctionality.php
+++ b/classes/PUI/PuiFunctionality.php
@@ -31,6 +31,7 @@ use Configuration;
 use Context;
 use Country;
 use PaypalAddons\classes\AbstractMethodPaypal;
+use PaypalAddons\classes\Constants\PaypalConfigurations;
 use PaypalAddons\classes\Constants\PUI;
 use Tools;
 
@@ -91,5 +92,10 @@ class PuiFunctionality
         $address = new Address($context->cart->id_address_delivery);
 
         return 'de' == Tools::strtolower(Country::getIsoById($address->id_country));
+    }
+
+    public function isEnabled()
+    {
+        return (bool) Configuration::get(PaypalConfigurations::PUI_ENABLED);
     }
 }

--- a/paypal.php
+++ b/paypal.php
@@ -780,8 +780,12 @@ class PayPal extends \PaymentModule implements WidgetInterface
                 }
 
                 if ($this->getWebhookOption()->isAvailable() && $this->getWebhookOption()->isEnable()) {
-                    if ($this->initPuiFunctionality()->isAvailable(false) && $this->initPuiFunctionality()->isEligibleContext($this->context)) {
-                        $payments_options[] = $this->renderPuiOption($params);
+                    if ($this->initPuiFunctionality()->isAvailable(false)) {
+                        if ($this->initPuiFunctionality()->isEnabled()) {
+                            if ($this->initPuiFunctionality()->isEligibleContext($this->context)) {
+                                $payments_options[] = $this->renderPuiOption($params);
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Paypal PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | PUI method appears even if it is disabled
| Type?         | bug fix
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
