### PR TITLE
refs #43285 ip restriction for banner

### DIFF
--- a/classes/InstallmentBanner/Banner.php
+++ b/classes/InstallmentBanner/Banner.php
@@ -73,6 +73,10 @@ class Banner
 
     public function render()
     {
+        if (!$this->method->isConfigured()) {
+            return '';
+        }
+
         $render = Context::getContext()->smarty
             ->assign('paypalmessenging', $this->getConfig())
             ->assign($this->getTplVars())


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Paypal PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | banner is displayed despite IP restriction
| Type?         | bug fix
| BC breaks?    |  no
| Deprecations? |  no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | Set IP restriction in the module configuration, then check if the banner is displayed

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
