### PR TITLE
refs #44049 removing Sofort payment method

### DIFF
--- a/classes/Form/CheckoutForm.php
+++ b/classes/Form/CheckoutForm.php
@@ -372,24 +372,27 @@ class CheckoutForm implements FormInterface
                 ],
                 'value' => (int) Configuration::get(PaypalConfigurations::GIROPAY_ENABLED),
             ];
-            $fields[PaypalConfigurations::SOFORT_ENABLED] = [
-                'type' => 'switch',
-                'label' => $this->module->l('Sofort', 'CheckoutForm'),
-                'name' => PaypalConfigurations::SOFORT_ENABLED,
-                'values' => [
-                    [
-                        'id' => PaypalConfigurations::SOFORT_ENABLED . '_on',
-                        'value' => 1,
-                        'label' => $this->module->l('Enabled', 'AdminPayPalCustomizeCheckoutController'),
+            // Do not show the 'Sofort' feature the new clients. Make this feature available only for those, who has already activated it
+            if ((int) Configuration::get(PaypalConfigurations::SOFORT_ENABLED)) {
+                $fields[PaypalConfigurations::SOFORT_ENABLED] = [
+                    'type' => 'switch',
+                    'label' => $this->module->l('Sofort', 'CheckoutForm'),
+                    'name' => PaypalConfigurations::SOFORT_ENABLED,
+                    'values' => [
+                        [
+                            'id' => PaypalConfigurations::SOFORT_ENABLED . '_on',
+                            'value' => 1,
+                            'label' => $this->module->l('Enabled', 'AdminPayPalCustomizeCheckoutController'),
+                        ],
+                        [
+                            'id' => PaypalConfigurations::SOFORT_ENABLED . '_off',
+                            'value' => 0,
+                            'label' => $this->module->l('Disabled', 'AdminPayPalCustomizeCheckoutController'),
+                        ],
                     ],
-                    [
-                        'id' => PaypalConfigurations::SOFORT_ENABLED . '_off',
-                        'value' => 0,
-                        'label' => $this->module->l('Disabled', 'AdminPayPalCustomizeCheckoutController'),
-                    ],
-                ],
-                'value' => (int) Configuration::get(PaypalConfigurations::SOFORT_ENABLED),
-            ];
+                    'value' => (int) Configuration::get(PaypalConfigurations::SOFORT_ENABLED),
+                ];
+            }
         }
 
         if ($this->vaultingFunctionality->isAvailable()) {

--- a/paypal.php
+++ b/paypal.php
@@ -389,7 +389,6 @@ class PayPal extends \PaymentModule implements WidgetInterface
             PaypalConfigurations::PUI_ENABLED => 1,
             PaypalConfigurations::SEPA_ENABLED => 1,
             PaypalConfigurations::GIROPAY_ENABLED => 1,
-            PaypalConfigurations::SOFORT_ENABLED => 1,
             PaypalConfigurations::ACDC_OPTION => 1,
         ];
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Paypal PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | 
Make the payment method 'Sofort' available only for those, who has already used it. For others it is unavailable.
| Type?         | new feature
| BC breaks?    |  no
| Deprecations? |  no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
