### PR TITLE
refs #44009 error during PaypalOrder::save()

### DIFF
--- a/paypal.php
+++ b/paypal.php
@@ -1554,7 +1554,7 @@ class PayPal extends \PaymentModule implements WidgetInterface
         $amount_paid = Tools::ps_round($amount_paid, 2);
 
         $cart = new Cart((int) $id_cart);
-        $total_ps = (float) $cart->getOrderTotal(true, Cart::BOTH);
+        $total_ps = Tools::ps_round((float) $cart->getOrderTotal(true, Cart::BOTH), 2);
         if ($amount_paid_curr > $total_ps + 0.10 || $amount_paid_curr < $total_ps - 0.10) {
             $total_ps = $amount_paid_curr;
         }


### PR DESCRIPTION
…nvalid

<!-----------------------------------------------------------------------------
Thank you for contributing to the Paypal PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | error during saving PaypalOrder object
| Type?         | bug fix 
| BC breaks?    |  no
| Deprecations? |  no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
