### PR TITLE
Fix: Configuration page problem with PS 8.1.5 on Windows

### DIFF
--- a/controllers/admin/AdminPaypalConfigurationController.php
+++ b/controllers/admin/AdminPaypalConfigurationController.php
@@ -109,9 +109,9 @@ class AdminPaypalConfigurationController extends \PaypalAddons\classes\AdminPayP
                 'messagingConfig' => Configuration::get(ConfigurationMap::MESSENGING_CONFIG, null, null, null, '{}'),
             ],
         ]);
-        $this->addJS(_PS_MODULE_DIR_ . 'paypal/views/js/admin.js');
+        $this->addJS(_MODULE_DIR_ . 'paypal/views/js/admin.js');
         $this->addJS('https://www.paypalobjects.com/merchant-library/merchant-configurator.js', false);
-        $this->addCSS(_PS_MODULE_DIR_ . 'paypal/views/css/paypal_bo.css');
+        $this->addCSS(_MODULE_DIR_ . 'paypal/views/css/paypal_bo.css');
     }
 
     public function initContent()


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Paypal PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The module configuration page in PS 8.1.5 is displayed poorly (on Windows)
| Type?         | bug fix 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #322.
| How to test?  | In PS 8 go to the module configuration page and check if you see the configuration correctly

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
