### PR TITLE
refs #45992 verify product availability before order creation

### DIFF
--- a/classes/AbstractMethodPaypal.php
+++ b/classes/AbstractMethodPaypal.php
@@ -234,31 +234,19 @@ abstract class AbstractMethodPaypal extends AbstractMethod
         $vaultingFunctionality = $this->initVaultingFunctionality();
 
         if (!Validate::isLoadedObject($customer)) {
-            throw new PaypalException(
-                PaypalException::INVALID_CUSTOMER,
-                'Customer is not loaded object'
-            );
+            throw new PaypalException(PaypalException::INVALID_CUSTOMER, 'Customer is not loaded object');
         }
         if (empty($this->getPaymentId())) {
-            throw new PaypalException(
-                PaypalException::ARGUMENT_MISSING,
-                'Payment ID isn\'t setted'
-            );
+            throw new PaypalException(PaypalException::ARGUMENT_MISSING, 'Payment ID isn\'t setted');
         }
         if (false === $this->isCorrectCart($cart, $this->getPaymentId())) {
-            throw new PaypalException(
-                PaypalException::CART_CHANGED,
-                'The elements in the shopping cart were changed. Please try to pay again.'
-            );
+            throw new PaypalException(PaypalException::CART_CHANGED, 'The elements in the shopping cart were changed. Please try to pay again.');
         }
         if ($cart->isAllProductsInStock() !== true ||
             (method_exists($cart, 'checkAllProductsAreStillAvailableInThisState') && $cart->checkAllProductsAreStillAvailableInThisState() !== true) ||
             (method_exists($cart, 'checkAllProductsHaveMinimalQuantities') && $cart->checkAllProductsHaveMinimalQuantities() !== true)
         ) {
-            throw new PaypalException(
-                PaypalException::PRODUCT_UNAVAILABLE,
-                sprintf('Cart with id %d contains products unavailable. Cannot capture the order.', (int) $cart->id)
-            );
+            throw new PaypalException(PaypalException::PRODUCT_UNAVAILABLE, sprintf('Cart with id %d contains products unavailable. Cannot capture the order.', (int) $cart->id));
         }
 
         $response = $this->completePayment();

--- a/classes/AbstractMethodPaypal.php
+++ b/classes/AbstractMethodPaypal.php
@@ -234,15 +234,31 @@ abstract class AbstractMethodPaypal extends AbstractMethod
         $vaultingFunctionality = $this->initVaultingFunctionality();
 
         if (!Validate::isLoadedObject($customer)) {
-            throw new Exception('Customer is not loaded object');
+            throw new PaypalException(
+                PaypalException::INVALID_CUSTOMER,
+                'Customer is not loaded object'
+            );
         }
-
-        if ($this->getPaymentId() == false) {
-            throw new Exception('Payment ID isn\'t setted');
+        if (empty($this->getPaymentId())) {
+            throw new PaypalException(
+                PaypalException::ARGUMENT_MISSING,
+                'Payment ID isn\'t setted'
+            );
         }
-
         if (false === $this->isCorrectCart($cart, $this->getPaymentId())) {
-            throw new Exception('The elements in the shopping cart were changed. Please try to pay again.');
+            throw new PaypalException(
+                PaypalException::CART_CHANGED,
+                'The elements in the shopping cart were changed. Please try to pay again.'
+            );
+        }
+        if ($cart->isAllProductsInStock() !== true ||
+            (method_exists($cart, 'checkAllProductsAreStillAvailableInThisState') && $cart->checkAllProductsAreStillAvailableInThisState() !== true) ||
+            (method_exists($cart, 'checkAllProductsHaveMinimalQuantities') && $cart->checkAllProductsHaveMinimalQuantities() !== true)
+        ) {
+            throw new PaypalException(
+                PaypalException::PRODUCT_UNAVAILABLE,
+                sprintf('Cart with id %d contains products unavailable. Cannot capture the order.', (int) $cart->id)
+            );
         }
 
         $response = $this->completePayment();

--- a/classes/PaypalException.php
+++ b/classes/PaypalException.php
@@ -39,6 +39,14 @@ if (!defined('_PS_VERSION_')) {
  */
 class PaypalException extends Exception
 {
+    const CART_CHANGED = 1001;
+
+    const PRODUCT_UNAVAILABLE = 1002;
+
+    const INVALID_CUSTOMER = 1003;
+
+    const ARGUMENT_MISSING = 1004;
+
     /** @var string Long detailed error message */
     private $message_long;
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Paypal PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Check product availability before an order creation
| Type?         | improvement
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
