### PR TITLE
fix: Undefined class constant 'GIROPAY_ENABLED'

### DIFF
--- a/classes/Constants/PaypalConfigurations.php
+++ b/classes/Constants/PaypalConfigurations.php
@@ -57,6 +57,8 @@ class PaypalConfigurations
 
     const SEPA_ENABLED = 'PAYPAL_SEPA_ENABLED';
 
+    const GIROPAY_ENABLED = 'GIROPAY_ENABLED';
+
     const SOFORT_ENABLED = 'PAYPAL_SOFORT_ENABLED';
 
     const VENMO_OPTION = 'PAYPAL_VENMO_ENABLED';


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Paypal PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This is an error on installing module 6.4.2
| Type?         | bug fix 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Install/ Upgrade the module (we upgraded from 6.2.0 on a customer store)

![grafik](https://github.com/user-attachments/assets/b3ee1aa0-dc9d-4481-adcf-71e3276d2734)

