### PR TITLE
Bugfix/47995 incorrect precision

### DIFF
--- a/paypal.php
+++ b/paypal.php
@@ -2325,12 +2325,21 @@ class PayPal extends \PaymentModule implements WidgetInterface
         return $response;
     }
 
-    public static function getPrecision()
+    public static function getPrecision($currency = null)
     {
         if (version_compare(_PS_VERSION_, '1.7.7', '<')) {
             return _PS_PRICE_DISPLAY_PRECISION_;
         } else {
-            return Context::getContext()->getComputingPrecision();
+            if ($currency instanceof Currency && Validate::isLoadedObject($currency)) {
+                $context = Context::getContext()->cloneContext();
+                $context->currency = $currency;
+                $precision = $context->getComputingPrecision();
+                unset($context);
+
+                return $precision;
+            } else {
+                return Context::getContext()->getComputingPrecision();
+            }
         }
     }
 
@@ -2348,7 +2357,7 @@ class PayPal extends \PaymentModule implements WidgetInterface
             $isoCurrency = $paypal->getPaymentCurrencyIso();
         }
 
-        $precision = self::getPrecision();
+        $precision = self::getPrecision(new Currency(Currency::getIdByIsoCode($isoCurrency)));
 
         if (in_array($isoCurrency, $currency_wt_decimal) || ($precision == 0)) {
             return (int) 0;

--- a/services/Order/RefundAmountCalculator.php
+++ b/services/Order/RefundAmountCalculator.php
@@ -32,7 +32,6 @@ if (!defined('_PS_VERSION_')) {
 }
 
 use Order;
-use PayPal;
 
 class RefundAmountCalculator
 {

--- a/services/Order/RefundAmountCalculator.php
+++ b/services/Order/RefundAmountCalculator.php
@@ -50,7 +50,7 @@ class RefundAmountCalculator
         }
 
         foreach ($params['productList'] as $product) {
-            $amount += \Tools::ps_round($product['amount'], PayPal::getPrecision());
+            $amount += (float) $product['amount'];
         }
 
         if (false == empty($params['partialRefundShippingCost'])) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Paypal PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The module tries to refund an incorrect amount
| Type?         | bug fix / improvement / new feature / refacto / critical
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | PrestaShop 1.7.7 or higher. Default currency is JPY. Create an order and pay it with EUR. Update order status to 'Refund'

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
