### PR TITLE
refs #49267 the alias list for PrestaShop iso country codes

### DIFF
--- a/services/TrackingParameters.php
+++ b/services/TrackingParameters.php
@@ -30,6 +30,7 @@ namespace PaypalAddons\services;
 use Configuration;
 use Country;
 use Exception;
+use PaypalAddons\classes\Constants\CountryIsoAlias;
 use PaypalAddons\classes\Constants\TrackingParameters as Map;
 use PrestaShopLogger;
 use Throwable;
@@ -64,19 +65,24 @@ class TrackingParameters
         $carriers = [
             [
                 'key' => Map::CARRIER_OTHER,
-                 'name' => Map::CARRIER_OTHER,
+                'name' => Map::CARRIER_OTHER,
             ],
         ];
+        $isoAliasList = CountryIsoAlias::getAliasList();
 
-        if ($isoCountry === null) {
-            $isoCountry = $this->defaultCountry->iso_code;
+        if (empty($this->paypalCarriers[$isoCountry])) {
+            if (empty($isoAliasList[$isoCountry]) || empty($this->paypalCarriers[$isoAliasList[$isoCountry]])) {
+                return $carriers;
+            }
+
+            $isoCountry = $isoAliasList[$isoCountry];
         }
 
         if (empty($this->paypalCarriers[strtoupper($isoCountry)])) {
             return $carriers;
         }
 
-        return array_merge($carriers, $this->paypalCarriers[strtoupper($isoCountry)]);
+        return array_merge($carriers, $this->paypalCarriers[$isoCountry]);
     }
 
     public function getPaypalCarrierByPsCarrier($carrierRef)


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Paypal PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Adding alias of iso country UK for GB which is necessary for correct determining paypal carrier while sending tracking info.
| Type?         | improvement
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes #318.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
