### PR TITLE
refs #50484 error on the module configuration page

### DIFF
--- a/vendor/ppbtlib/src/Extensions/Diagnostic/Stubs/Handler/FileIntegrityStubHandler.php
+++ b/vendor/ppbtlib/src/Extensions/Diagnostic/Stubs/Handler/FileIntegrityStubHandler.php
@@ -48,10 +48,12 @@ class FileIntegrityStubHandler extends AbstractStubHandler
         ];
         $respositoryInfo = $this->getRepositoryInfo();
         foreach ($respositoryInfo as $repository) {
-            if ($repository['tag_name'] == $this->getStub()->getParameters()->getModuleVersion()) {
-                $differences = $this->getDifferences($repository);
-                if(!empty($differences)) {
-                    return array_merge($differences, $response);
+            if (isset($repository['tag_name'])) {
+                if ($repository['tag_name'] == $this->getStub()->getParameters()->getModuleVersion()) {
+                    $differences = $this->getDifferences($repository);
+                    if(!empty($differences)) {
+                        return array_merge($differences, $response);
+                    }
                 }
             }
         }
@@ -85,7 +87,7 @@ class FileIntegrityStubHandler extends AbstractStubHandler
 
         $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         curl_close($ch);
-        if ($httpcode == '404') {
+        if ($httpcode < 200 || $httpcode >= 300) {
             return [];
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Paypal PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Error "Cannot access offset of type string on string" on the module configuration page
| Type?         | bug fix
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
