### PR TITLE
refs #54038 do not send tax type if tva is not set

### DIFF
--- a/classes/MethodMB.php
+++ b/classes/MethodMB.php
@@ -276,8 +276,12 @@ class MethodMB extends AbstractMethodPaypal
         }
 
         $taxId = str_replace(['.', '-', '/'], '', $addressCustomer->vat_number);
-        $taxInfo['tax_id'] = $taxId;
-        $taxInfo['tax_id_type'] = $this->getTaxIdType($taxId);
+        $taxIdType = $this->getTaxIdType($taxId);
+
+        if (empty($taxIdType) === false) {
+            $taxInfo['tax_id'] = $taxId;
+            $taxInfo['tax_id_type'] = $this->getTaxIdType($taxId);
+        }
 
         return $taxInfo;
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Paypal PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | do not send tax type if vat number is not set (MX and BR)
| Type?         | bug fix
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
